### PR TITLE
Add persistent storage (SLOAD/SSTORE)

### DIFF
--- a/lib/eevm/executor.ex
+++ b/lib/eevm/executor.ex
@@ -25,7 +25,7 @@ defmodule EEVM.Executor do
   - `import Bitwise` gives us operators like `band`, `bor`, `bxor`, `bnot`.
   """
 
-  alias EEVM.{MachineState, Stack, Memory, Opcodes, Gas}
+  alias EEVM.{MachineState, Stack, Memory, Storage, Opcodes, Gas}
 
   import Bitwise
 
@@ -422,6 +422,46 @@ defmodule EEVM.Executor do
     else
       {:error, reason} -> {:error, reason, state}
       {:error, :out_of_gas, halted_state} -> {:error, :out_of_gas, halted_state}
+    end
+  end
+
+  # SLOAD (0x54): load from storage
+  #
+  # Pops a key from the stack, looks it up in storage, and pushes the value.
+  # Uninitialized slots return 0.
+  #
+  # ## Elixir Learning Note
+  #
+  # `Storage.load/2` uses `Map.get/3` with a default of 0, so we never
+  # need to check if the key exists — missing keys just return 0.
+  defp execute_opcode(0x54, state) do
+    with {:ok, key, s1} <- Stack.pop(state.stack),
+         value = Storage.load(state.storage, key),
+         {:ok, s2} <- Stack.push(s1, value) do
+      {:ok, %{state | stack: s2} |> MachineState.advance_pc()}
+    else
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
+  # SSTORE (0x55): store to storage
+  #
+  # Pops a key and value from the stack, writes the value to storage.
+  # This is the most expensive common opcode (20,000 gas) because it
+  # modifies persistent blockchain state.
+  #
+  # ## Elixir Learning Note
+  #
+  # `Storage.store/3` returns a *new* storage struct — it doesn't mutate
+  # the old one. This is functional programming: every "write" creates a
+  # new version of the data structure.
+  defp execute_opcode(0x55, state) do
+    with {:ok, key, s1} <- Stack.pop(state.stack),
+         {:ok, value, s2} <- Stack.pop(s1) do
+      new_storage = Storage.store(state.storage, key, value)
+      {:ok, %{state | stack: s2, storage: new_storage} |> MachineState.advance_pc()}
+    else
+      {:error, reason} -> {:error, reason, state}
     end
   end
 

--- a/lib/eevm/gas.ex
+++ b/lib/eevm/gas.ex
@@ -45,6 +45,8 @@ defmodule EEVM.Gas do
   @gas_keccak256 30
   @gas_keccak256_word 6
   @gas_memory 3
+  @gas_sload 200
+  @gas_sstore 20_000
 
   @doc """
   Returns the static gas cost for a given opcode byte.
@@ -144,6 +146,12 @@ defmodule EEVM.Gas do
   def static_cost(0x59), do: @gas_base
   # JUMPDEST
   def static_cost(0x5B), do: @gas_jumpdest
+
+  # Storage (0x54–0x55)
+  # SLOAD
+  def static_cost(0x54), do: @gas_sload
+  # SSTORE
+  def static_cost(0x55), do: @gas_sstore
 
   # PUSH1–PUSH32 (0x60–0x7F)
   def static_cost(op) when op >= 0x60 and op <= 0x7F, do: @gas_very_low

--- a/lib/eevm/machine_state.ex
+++ b/lib/eevm/machine_state.ex
@@ -21,14 +21,15 @@ defmodule EEVM.MachineState do
   - The `alias` keyword lets us reference modules by their short name.
   """
 
-  alias EEVM.{Stack, Memory}
+  alias EEVM.{Stack, Memory, Storage}
 
-  @type status :: :running | :stopped | :reverted | :invalid
+  @type status :: :running | :stopped | :reverted | :invalid | :out_of_gas
 
   @type t :: %__MODULE__{
           pc: non_neg_integer(),
           stack: Stack.t(),
           memory: Memory.t(),
+          storage: Storage.t(),
           gas: non_neg_integer(),
           status: status(),
           return_data: binary(),
@@ -39,6 +40,7 @@ defmodule EEVM.MachineState do
   defstruct pc: 0,
             stack: nil,
             memory: nil,
+            storage: nil,
             gas: 1_000_000,
             status: :running,
             return_data: <<>>,
@@ -51,6 +53,7 @@ defmodule EEVM.MachineState do
     - `code` — the raw EVM bytecode as an Elixir binary
     - `opts` — optional keyword list:
       - `:gas` — initial gas (default: 1,000,000)
+      - `:storage` — initial storage (default: empty)
 
   ## Example
 
@@ -64,6 +67,7 @@ defmodule EEVM.MachineState do
       code: code,
       stack: Stack.new(),
       memory: Memory.new(),
+      storage: Keyword.get(opts, :storage, Storage.new()),
       gas: Keyword.get(opts, :gas, 1_000_000)
     }
   end

--- a/lib/eevm/opcodes.ex
+++ b/lib/eevm/opcodes.ex
@@ -55,6 +55,8 @@ defmodule EEVM.Opcodes do
   @mload 0x51
   @mstore 0x52
   @mstore8 0x53
+  @sload 0x54
+  @sstore 0x55
   @msize 0x59
   @jump 0x56
   @jumpi 0x57
@@ -120,6 +122,8 @@ defmodule EEVM.Opcodes do
   def info(@mload), do: {:ok, %{name: "MLOAD", inputs: 1, outputs: 1}}
   def info(@mstore), do: {:ok, %{name: "MSTORE", inputs: 2, outputs: 0}}
   def info(@mstore8), do: {:ok, %{name: "MSTORE8", inputs: 2, outputs: 0}}
+  def info(@sload), do: {:ok, %{name: "SLOAD", inputs: 1, outputs: 1}}
+  def info(@sstore), do: {:ok, %{name: "SSTORE", inputs: 2, outputs: 0}}
   def info(@msize), do: {:ok, %{name: "MSIZE", inputs: 0, outputs: 1}}
   def info(@jump), do: {:ok, %{name: "JUMP", inputs: 1, outputs: 0}}
   def info(@jumpi), do: {:ok, %{name: "JUMPI", inputs: 2, outputs: 0}}

--- a/lib/eevm/storage.ex
+++ b/lib/eevm/storage.ex
@@ -1,0 +1,117 @@
+defmodule EEVM.Storage do
+  @moduledoc """
+  Persistent key-value storage for the EVM.
+
+  ## EVM Concepts
+
+  Storage is the EVM's persistent state — it survives across transactions and
+  blocks. Each contract (account) has its own isolated storage, a mapping from
+  256-bit keys ("slots") to 256-bit values.
+
+  This is what makes Ethereum a *stateful* computer. When a Solidity contract
+  declares `uint256 public counter`, that variable lives in storage slot 0.
+  `SSTORE` writes to it, `SLOAD` reads from it.
+
+  ### Storage vs Memory
+
+  | Property | Storage | Memory |
+  |----------|---------|--------|
+  | Lifetime | Permanent (on-chain) | Cleared after each call |
+  | Cost | Very expensive (20,000 gas to write) | Cheap (3 gas + expansion) |
+  | Size | 2^256 slots per account | Grows dynamically |
+  | Access | Key-value (slot → value) | Byte-addressable (offset → byte) |
+
+  ### Gas Costs (Simplified)
+
+  In a production EVM, storage gas depends on cold/warm access (EIP-2929) and
+  whether you're writing to a fresh vs dirty slot (EIP-2200). We use simplified
+  flat costs for learning:
+
+  - `SLOAD`: 200 gas (warm access cost)
+  - `SSTORE`: 20,000 gas (fresh write cost)
+
+  The full EIP-2929 + EIP-2200 model tracks an "access set" per transaction and
+  distinguishes between original, current, and new values to compute refunds.
+
+  ## Elixir Learning Notes
+
+  - We use a plain `Map` as the underlying data structure. Elixir maps have
+    O(log n) access which is fine for our learning purposes.
+  - Uninitialized slots return 0 — we use `Map.get/3` with a default value
+    rather than checking for key existence.
+  - The module is purely functional: `store/3` returns a new storage, it doesn't
+    mutate the old one. This is a core Elixir/functional programming pattern.
+  """
+
+  @type t :: %__MODULE__{
+          slots: %{non_neg_integer() => non_neg_integer()}
+        }
+
+  defstruct slots: %{}
+
+  @doc "Creates a new empty storage."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc """
+  Creates storage pre-loaded with initial slot values.
+
+  Useful for testing or simulating contract state.
+
+  ## Example
+
+      iex> storage = EEVM.Storage.new(%{0 => 42, 1 => 100})
+      iex> EEVM.Storage.load(storage, 0)
+      42
+  """
+  @spec new(%{non_neg_integer() => non_neg_integer()}) :: t()
+  def new(initial) when is_map(initial) do
+    %__MODULE__{slots: initial}
+  end
+
+  @doc """
+  Loads a value from a storage slot.
+
+  Returns 0 for uninitialized slots — the EVM treats all 2^256 slots as
+  existing with a default value of 0.
+
+  ## Example
+
+      iex> storage = EEVM.Storage.new()
+      iex> EEVM.Storage.load(storage, 42)
+      0
+  """
+  @spec load(t(), non_neg_integer()) :: non_neg_integer()
+  def load(%__MODULE__{slots: slots}, key) do
+    Map.get(slots, key, 0)
+  end
+
+  @doc """
+  Stores a value into a storage slot.
+
+  Returns the updated storage. Writing 0 to a slot is valid and keeps the
+  key in the map (in a production EVM, this could trigger a gas refund).
+
+  ## Example
+
+      iex> storage = EEVM.Storage.new() |> EEVM.Storage.store(0, 42)
+      iex> EEVM.Storage.load(storage, 0)
+      42
+  """
+  @spec store(t(), non_neg_integer(), non_neg_integer()) :: t()
+  def store(%__MODULE__{slots: slots}, key, value) do
+    %__MODULE__{slots: Map.put(slots, key, band_256(value))}
+  end
+
+  @doc """
+  Returns the storage contents as a map for inspection.
+  """
+  @spec to_map(t()) :: %{non_neg_integer() => non_neg_integer()}
+  def to_map(%__MODULE__{slots: slots}), do: slots
+
+  # Masks to 256 bits — all EVM values are uint256.
+  defp band_256(value) do
+    import Bitwise
+    Bitwise.band(value, (1 <<< 256) - 1)
+  end
+end

--- a/test/eevm_test.exs
+++ b/test/eevm_test.exs
@@ -3,7 +3,7 @@ defmodule EEVMTest do
   import Bitwise
   doctest EEVM
 
-  alias EEVM.{Stack, Memory, Gas}
+  alias EEVM.{Stack, Memory, Storage, Gas}
 
   # ── Stack Tests ──────────────────────────────────────────────────────
 
@@ -479,6 +479,99 @@ defmodule EEVMTest do
       result = EEVM.execute(code, gas: 1000)
       # PUSH1=3, JUMP=8, JUMPDEST=1, STOP=0 → 12
       assert result.gas == 1000 - 12
+    end
+  end
+
+  # ── Storage Tests ──────────────────────────────────────────────────
+
+  describe "Storage (SLOAD/SSTORE)" do
+    test "SSTORE then SLOAD retrieves the stored value" do
+      # PUSH1 42, PUSH1 0, SSTORE, PUSH1 0, SLOAD, STOP
+      code = <<0x60, 42, 0x60, 0, 0x55, 0x60, 0, 0x54, 0x00>>
+      result = EEVM.execute(code)
+      assert result.status == :stopped
+      assert EEVM.stack_values(result) == [42]
+    end
+
+    test "SLOAD of uninitialized slot returns 0" do
+      # PUSH1 99, SLOAD, STOP
+      code = <<0x60, 99, 0x54, 0x00>>
+      result = EEVM.execute(code)
+      assert result.status == :stopped
+      assert EEVM.stack_values(result) == [0]
+    end
+
+    test "SSTORE overwrites previous value" do
+      # Store 10 at slot 0, then store 20 at slot 0, then load slot 0
+      code =
+        <<0x60, 10, 0x60, 0, 0x55>> <>
+          <<0x60, 20, 0x60, 0, 0x55>> <>
+          <<0x60, 0, 0x54, 0x00>>
+
+      result = EEVM.execute(code)
+      assert EEVM.stack_values(result) == [20]
+    end
+
+    test "SSTORE and SLOAD with different slots" do
+      # Store 111 at slot 0, store 222 at slot 1, load slot 0, load slot 1
+      code =
+        <<0x60, 111, 0x60, 0, 0x55>> <>
+          <<0x60, 222, 0x60, 1, 0x55>> <>
+          <<0x60, 0, 0x54>> <>
+          <<0x60, 1, 0x54, 0x00>>
+
+      result = EEVM.execute(code)
+      # Stack: [slot1_val, slot0_val] (top first)
+      assert EEVM.stack_values(result) == [222, 111]
+    end
+
+    test "SLOAD with pre-loaded storage" do
+      # Pre-load slot 5 with value 9999, then SLOAD it
+      storage = Storage.new(%{5 => 9999})
+      code = <<0x60, 5, 0x54, 0x00>>
+      result = EEVM.execute(code, storage: storage)
+      assert EEVM.stack_values(result) == [9999]
+    end
+
+    test "SSTORE gas cost is 20000" do
+      # PUSH1 1, PUSH1 0, SSTORE, STOP
+      # Gas: PUSH1=3 + PUSH1=3 + SSTORE=20000 + STOP=0 = 20006
+      code = <<0x60, 1, 0x60, 0, 0x55, 0x00>>
+      result = EEVM.execute(code, gas: 100_000)
+      assert result.gas == 100_000 - 20_006
+    end
+
+    test "SLOAD gas cost is 200" do
+      # PUSH1 0, SLOAD, STOP
+      # Gas: PUSH1=3 + SLOAD=200 + STOP=0 = 203
+      code = <<0x60, 0, 0x54, 0x00>>
+      result = EEVM.execute(code, gas: 1_000)
+      assert result.gas == 1_000 - 203
+    end
+
+    test "SSTORE out of gas" do
+      # SSTORE costs 20000 — give only 100
+      code = <<0x60, 1, 0x60, 0, 0x55, 0x00>>
+      result = EEVM.execute(code, gas: 100)
+      assert result.status == :out_of_gas
+    end
+
+    test "storage persists across multiple SLOAD calls" do
+      # Store 7 at slot 3, load slot 3 twice
+      code =
+        <<0x60, 7, 0x60, 3, 0x55>> <>
+          <<0x60, 3, 0x54>> <>
+          <<0x60, 3, 0x54, 0x00>>
+
+      result = EEVM.execute(code)
+      assert EEVM.stack_values(result) == [7, 7]
+    end
+
+    test "storage is in final machine state" do
+      # Store 42 at slot 0
+      code = <<0x60, 42, 0x60, 0, 0x55, 0x00>>
+      result = EEVM.execute(code)
+      assert Storage.load(result.storage, 0) == 42
     end
   end
 end


### PR DESCRIPTION
Implements the EVM's persistent key-value storage model:

- New EEVM.Storage module with slot-based key-value storage (Map-backed, uint256 keys and values, 0 default for uninitialized slots)
- MachineState now carries a storage field, configurable via opts
- SLOAD (0x54): pops key, pushes value from storage (200 gas)
- SSTORE (0x55): pops key and value, writes to storage (20,000 gas)
- Opcodes and gas modules updated with SLOAD/SSTORE definitions
- 10 new tests: basic store/load, overwrite, multiple slots, pre-loaded storage, gas costs, out-of-gas, state inspection
- Extensive learning docs comparing storage vs memory