### PR TITLE
Add environment opcodes and ExecutionContext

### DIFF
--- a/lib/eevm/execution_context.ex
+++ b/lib/eevm/execution_context.ex
@@ -1,0 +1,170 @@
+defmodule EEVM.ExecutionContext do
+  @moduledoc """
+  The execution environment — external information available to the EVM.
+
+  ## EVM Concepts
+
+  The EVM doesn't execute in a vacuum. Every execution has a *context* — who
+  called the contract, how much ETH they sent, what block it's running in,
+  what data they passed as input. Environment opcodes let contracts read
+  this context.
+
+  This is the "Host" interface — revm calls it `ContextTr`, the Yellow Paper
+  calls it the execution environment `I`.
+
+  ### Three Layers of Context
+
+  1. **Transaction** — who sent the tx (`origin`), what gas price they're paying
+  2. **Message** — the current call frame: `caller`, `value`, `calldata`, `address`
+  3. **Block** — the block being built: `number`, `timestamp`, `coinbase`, `gaslimit`, etc.
+
+  ### Opcodes That Read Context
+
+  | Opcode | Byte | Reads | Gas |
+  |--------|------|-------|-----|
+  | ADDRESS | 0x30 | Current contract address | 2 |
+  | BALANCE | 0x31 | Balance of an address | 2600 (cold) |
+  | ORIGIN | 0x32 | Transaction sender (EOA) | 2 |
+  | CALLER | 0x33 | Direct caller of this frame | 2 |
+  | CALLVALUE | 0x34 | ETH sent with this call | 2 |
+  | CALLDATALOAD | 0x35 | 32 bytes of calldata at offset | 3 |
+  | CALLDATASIZE | 0x36 | Length of calldata | 2 |
+  | CALLDATACOPY | 0x37 | Copy calldata to memory | 3 + mem |
+  | CODESIZE | 0x38 | Size of executing code | 2 |
+  | GASPRICE | 0x3A | Gas price of the tx | 2 |
+  | RETURNDATASIZE | 0x3D | Size of last return data | 2 |
+  | BLOCKHASH | 0x40 | Hash of a recent block | 20 |
+  | COINBASE | 0x41 | Block producer's address | 2 |
+  | TIMESTAMP | 0x42 | Block timestamp | 2 |
+  | NUMBER | 0x43 | Block number | 2 |
+  | PREVRANDAO | 0x44 | Previous block's RANDAO value | 2 |
+  | GASLIMIT | 0x45 | Block gas limit | 2 |
+  | CHAINID | 0x46 | Chain ID (1 = mainnet) | 2 |
+  | SELFBALANCE | 0x47 | Balance of executing contract | 5 |
+  | BASEFEE | 0x48 | Block base fee (EIP-1559) | 2 |
+  | GAS | 0x5A | Remaining gas | 2 |
+
+  ## Elixir Learning Notes
+
+  - We use a flat struct with sensible defaults. In a production EVM (like revm),
+    these would be separate traits (`Transaction`, `Block`, `Cfg`), but for
+    learning a flat struct is clearer.
+  - Default values make it easy to construct partial contexts for testing —
+    you only set what you need.
+  - The `calldata` field is a raw binary (`<<>>`) — Elixir excels at binary
+    pattern matching, which we use in CALLDATALOAD/CALLDATACOPY.
+  """
+
+  @type t :: %__MODULE__{
+          # Message context (current call frame)
+          address: non_neg_integer(),
+          caller: non_neg_integer(),
+          origin: non_neg_integer(),
+          callvalue: non_neg_integer(),
+          calldata: binary(),
+          gasprice: non_neg_integer(),
+          # Block context
+          block_number: non_neg_integer(),
+          block_timestamp: non_neg_integer(),
+          block_coinbase: non_neg_integer(),
+          block_gaslimit: non_neg_integer(),
+          block_prevrandao: non_neg_integer(),
+          block_basefee: non_neg_integer(),
+          block_chainid: non_neg_integer(),
+          # Account balances — simplified as a map
+          balances: %{non_neg_integer() => non_neg_integer()},
+          # Block hashes — map of block_number => hash (last 256 blocks)
+          block_hashes: %{non_neg_integer() => non_neg_integer()}
+        }
+
+  defstruct address: 0,
+            caller: 0,
+            origin: 0,
+            callvalue: 0,
+            calldata: <<>>,
+            gasprice: 0,
+            block_number: 0,
+            block_timestamp: 0,
+            block_coinbase: 0,
+            block_gaslimit: 0,
+            block_prevrandao: 0,
+            block_basefee: 0,
+            block_chainid: 1,
+            balances: %{},
+            block_hashes: %{}
+
+  @doc "Creates a new execution context with default values."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc """
+  Creates a new execution context with the given overrides.
+
+  ## Example
+
+      iex> ctx = EEVM.ExecutionContext.new(caller: 0xDEAD, callvalue: 1000)
+      iex> ctx.caller
+      0xDEAD
+  """
+  @spec new(keyword()) :: t()
+  def new(opts) when is_list(opts) do
+    struct!(__MODULE__, opts)
+  end
+
+  @doc """
+  Returns the balance of an address.
+
+  Returns 0 for unknown addresses.
+  """
+  @spec balance(t(), non_neg_integer()) :: non_neg_integer()
+  def balance(%__MODULE__{balances: balances}, address) do
+    Map.get(balances, address, 0)
+  end
+
+  @doc """
+  Reads 32 bytes from calldata starting at the given byte offset.
+
+  Calldata shorter than offset+32 is right-padded with zeros, matching
+  EVM spec behavior. This is what CALLDATALOAD does.
+
+  ## Elixir Learning Note
+
+  We use `binary_part/3` with bounds checking and manual zero-padding.
+  Elixir binaries are immutable byte sequences — slicing them is O(1).
+  """
+  @spec calldata_load(t(), non_neg_integer()) :: non_neg_integer()
+  def calldata_load(%__MODULE__{calldata: calldata}, offset) do
+    size = byte_size(calldata)
+
+    bytes =
+      cond do
+        offset >= size ->
+          <<0::256>>
+
+        offset + 32 > size ->
+          available = binary_part(calldata, offset, size - offset)
+          pad_len = 32 - byte_size(available)
+          available <> <<0::size(pad_len * 8)>>
+
+        true ->
+          binary_part(calldata, offset, 32)
+      end
+
+    <<value::unsigned-big-256>> = bytes
+    value
+  end
+
+  @doc """
+  Returns the block hash for a given block number.
+
+  Returns 0 if the block number is not in the last 256 blocks.
+  """
+  @spec block_hash(t(), non_neg_integer()) :: non_neg_integer()
+  def block_hash(%__MODULE__{block_hashes: hashes, block_number: current}, number) do
+    if number < current and number >= max(0, current - 256) do
+      Map.get(hashes, number, 0)
+    else
+      0
+    end
+  end
+end

--- a/lib/eevm/executor.ex
+++ b/lib/eevm/executor.ex
@@ -25,7 +25,7 @@ defmodule EEVM.Executor do
   - `import Bitwise` gives us operators like `band`, `bor`, `bxor`, `bnot`.
   """
 
-  alias EEVM.{MachineState, Stack, Memory, Storage, Opcodes, Gas}
+  alias EEVM.{MachineState, Stack, Memory, Storage, ExecutionContext, Opcodes, Gas}
 
   import Bitwise
 
@@ -465,6 +465,189 @@ defmodule EEVM.Executor do
     end
   end
 
+  # ── Environment Opcodes ──────────────────────────────────────────────
+  #
+  # These opcodes read from the ExecutionContext — information about
+  # the current call, transaction, and block. They don't modify state,
+  # just push values onto the stack.
+  #
+  # ## Elixir Learning Note
+  #
+  # These are all trivially simple: read a field, push it. The pattern
+  # `state.context.field` chains struct access. In Elixir, this is
+  # syntactic sugar for `Map.get(Map.get(state, :context), :field)`.
+
+  # ADDRESS (0x30): push the executing contract's address
+  defp execute_opcode(0x30, state) do
+    push_value(state, state.context.address)
+  end
+
+  # BALANCE (0x31): pop address, push its balance
+  defp execute_opcode(0x31, state) do
+    with {:ok, addr, s1} <- Stack.pop(state.stack),
+         balance = ExecutionContext.balance(state.context, addr),
+         {:ok, s2} <- Stack.push(s1, balance) do
+      {:ok, %{state | stack: s2} |> MachineState.advance_pc()}
+    else
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
+  # ORIGIN (0x32): push the transaction sender (EOA, not the direct caller)
+  defp execute_opcode(0x32, state) do
+    push_value(state, state.context.origin)
+  end
+
+  # CALLER (0x33): push the direct caller of this call frame
+  defp execute_opcode(0x33, state) do
+    push_value(state, state.context.caller)
+  end
+
+  # CALLVALUE (0x34): push the ETH (in wei) sent with this call
+  defp execute_opcode(0x34, state) do
+    push_value(state, state.context.callvalue)
+  end
+
+  # CALLDATALOAD (0x35): pop offset, push 32 bytes of calldata
+  defp execute_opcode(0x35, state) do
+    with {:ok, offset, s1} <- Stack.pop(state.stack),
+         value = ExecutionContext.calldata_load(state.context, offset),
+         {:ok, s2} <- Stack.push(s1, value) do
+      {:ok, %{state | stack: s2} |> MachineState.advance_pc()}
+    else
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
+  # CALLDATASIZE (0x36): push the byte length of calldata
+  defp execute_opcode(0x36, state) do
+    push_value(state, byte_size(state.context.calldata))
+  end
+
+  # CALLDATACOPY (0x37): copy calldata to memory
+  #
+  # Pops: dest_offset, data_offset, length
+  # Copies `length` bytes from calldata starting at `data_offset`
+  # into memory starting at `dest_offset`.
+  defp execute_opcode(0x37, state) do
+    with {:ok, dest_offset, s1} <- Stack.pop(state.stack),
+         {:ok, data_offset, s2} <- Stack.pop(s1),
+         {:ok, length, s3} <- Stack.pop(s2) do
+      if length == 0 do
+        {:ok, %{state | stack: s3} |> MachineState.advance_pc()}
+      else
+        # Charge memory expansion gas
+        expansion_cost = Gas.memory_expansion_cost(Memory.size(state.memory), dest_offset, length)
+
+        case MachineState.consume_gas(%{state | stack: s3}, expansion_cost) do
+          {:ok, state_after_gas} ->
+            calldata = state_after_gas.context.calldata
+            cd_size = byte_size(calldata)
+
+            # Extract bytes from calldata, zero-padding beyond its end
+            bytes =
+              for i <- 0..(length - 1), into: <<>> do
+                if data_offset + i < cd_size do
+                  <<:binary.at(calldata, data_offset + i)>>
+                else
+                  <<0>>
+                end
+              end
+
+            # Write bytes to memory one at a time
+            new_memory =
+              bytes
+              |> :binary.bin_to_list()
+              |> Enum.with_index()
+              |> Enum.reduce(state_after_gas.memory, fn {byte, i}, mem ->
+                Memory.store_byte(mem, dest_offset + i, byte)
+              end)
+
+            {:ok, %{state_after_gas | memory: new_memory} |> MachineState.advance_pc()}
+
+          {:error, :out_of_gas, halted_state} ->
+            {:error, :out_of_gas, halted_state}
+        end
+      end
+    else
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
+  # CODESIZE (0x38): push the byte length of the executing code
+  defp execute_opcode(0x38, state) do
+    push_value(state, byte_size(state.code))
+  end
+
+  # GASPRICE (0x3A): push the gas price of the transaction
+  defp execute_opcode(0x3A, state) do
+    push_value(state, state.context.gasprice)
+  end
+
+  # RETURNDATASIZE (0x3D): push the size of the last RETURN/REVERT data
+  defp execute_opcode(0x3D, state) do
+    push_value(state, byte_size(state.return_data))
+  end
+
+  # BLOCKHASH (0x40): pop block number, push its hash
+  defp execute_opcode(0x40, state) do
+    with {:ok, block_num, s1} <- Stack.pop(state.stack),
+         hash = ExecutionContext.block_hash(state.context, block_num),
+         {:ok, s2} <- Stack.push(s1, hash) do
+      {:ok, %{state | stack: s2} |> MachineState.advance_pc()}
+    else
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
+  # COINBASE (0x41): push the block producer's address
+  defp execute_opcode(0x41, state) do
+    push_value(state, state.context.block_coinbase)
+  end
+
+  # TIMESTAMP (0x42): push the block timestamp
+  defp execute_opcode(0x42, state) do
+    push_value(state, state.context.block_timestamp)
+  end
+
+  # NUMBER (0x43): push the block number
+  defp execute_opcode(0x43, state) do
+    push_value(state, state.context.block_number)
+  end
+
+  # PREVRANDAO (0x44): push the previous block's RANDAO mix
+  defp execute_opcode(0x44, state) do
+    push_value(state, state.context.block_prevrandao)
+  end
+
+  # GASLIMIT (0x45): push the block gas limit
+  defp execute_opcode(0x45, state) do
+    push_value(state, state.context.block_gaslimit)
+  end
+
+  # CHAINID (0x46): push the chain ID (1 = mainnet)
+  defp execute_opcode(0x46, state) do
+    push_value(state, state.context.block_chainid)
+  end
+
+  # SELFBALANCE (0x47): push the balance of the executing contract
+  defp execute_opcode(0x47, state) do
+    balance = ExecutionContext.balance(state.context, state.context.address)
+    push_value(state, balance)
+  end
+
+  # BASEFEE (0x48): push the block's base fee (EIP-1559)
+  defp execute_opcode(0x48, state) do
+    push_value(state, state.context.block_basefee)
+  end
+
+  # GAS (0x5A): push remaining gas (after this opcode's cost)
+  defp execute_opcode(0x5A, state) do
+    push_value(state, state.gas)
+  end
+
+  # ── End Environment Opcodes ──────────────────────────────────────────
+
   # MSIZE (0x59): get memory size
   defp execute_opcode(0x59, state) do
     size = Memory.size(state.memory)
@@ -679,6 +862,13 @@ defmodule EEVM.Executor do
     else
       rem(half_sq * rem(base, m), m)
     end
+  end
+
+  # Helper for environment opcodes that just push a single value.
+  # Reduces boilerplate — most env ops are: read field, push, advance PC.
+  defp push_value(state, value) do
+    {:ok, new_stack} = Stack.push(state.stack, value)
+    {:ok, %{state | stack: new_stack} |> MachineState.advance_pc()}
   end
 
   # Checks if a position in the code is a valid JUMPDEST

--- a/lib/eevm/gas.ex
+++ b/lib/eevm/gas.ex
@@ -47,6 +47,9 @@ defmodule EEVM.Gas do
   @gas_memory 3
   @gas_sload 200
   @gas_sstore 20_000
+  @gas_blockhash 20
+  @gas_balance 2600
+  @gas_selfbalance 5
 
   @doc """
   Returns the static gas cost for a given opcode byte.
@@ -126,6 +129,50 @@ defmodule EEVM.Gas do
 
   # KECCAK256 (0x20) — static + dynamic per word
   def static_cost(0x20), do: @gas_keccak256
+
+  # Environment opcodes (0x30–0x48)
+  # ADDRESS
+  def static_cost(0x30), do: @gas_base
+  # BALANCE (cold access, simplified)
+  def static_cost(0x31), do: @gas_balance
+  # ORIGIN
+  def static_cost(0x32), do: @gas_base
+  # CALLER
+  def static_cost(0x33), do: @gas_base
+  # CALLVALUE
+  def static_cost(0x34), do: @gas_base
+  # CALLDATALOAD
+  def static_cost(0x35), do: @gas_very_low
+  # CALLDATASIZE
+  def static_cost(0x36), do: @gas_base
+  # CALLDATACOPY (static part, + memory expansion)
+  def static_cost(0x37), do: @gas_very_low
+  # CODESIZE
+  def static_cost(0x38), do: @gas_base
+  # GASPRICE
+  def static_cost(0x3A), do: @gas_base
+  # RETURNDATASIZE
+  def static_cost(0x3D), do: @gas_base
+  # BLOCKHASH
+  def static_cost(0x40), do: @gas_blockhash
+  # COINBASE
+  def static_cost(0x41), do: @gas_base
+  # TIMESTAMP
+  def static_cost(0x42), do: @gas_base
+  # NUMBER
+  def static_cost(0x43), do: @gas_base
+  # PREVRANDAO
+  def static_cost(0x44), do: @gas_base
+  # GASLIMIT
+  def static_cost(0x45), do: @gas_base
+  # CHAINID
+  def static_cost(0x46), do: @gas_base
+  # SELFBALANCE
+  def static_cost(0x47), do: @gas_selfbalance
+  # BASEFEE
+  def static_cost(0x48), do: @gas_base
+  # GAS
+  def static_cost(0x5A), do: @gas_base
 
   # Stack, Memory, Control Flow (0x50–0x5B)
   # POP

--- a/lib/eevm/machine_state.ex
+++ b/lib/eevm/machine_state.ex
@@ -21,7 +21,7 @@ defmodule EEVM.MachineState do
   - The `alias` keyword lets us reference modules by their short name.
   """
 
-  alias EEVM.{Stack, Memory, Storage}
+  alias EEVM.{Stack, Memory, Storage, ExecutionContext}
 
   @type status :: :running | :stopped | :reverted | :invalid | :out_of_gas
 
@@ -30,6 +30,7 @@ defmodule EEVM.MachineState do
           stack: Stack.t(),
           memory: Memory.t(),
           storage: Storage.t(),
+          context: ExecutionContext.t(),
           gas: non_neg_integer(),
           status: status(),
           return_data: binary(),
@@ -41,6 +42,7 @@ defmodule EEVM.MachineState do
             stack: nil,
             memory: nil,
             storage: nil,
+            context: nil,
             gas: 1_000_000,
             status: :running,
             return_data: <<>>,
@@ -54,6 +56,7 @@ defmodule EEVM.MachineState do
     - `opts` — optional keyword list:
       - `:gas` — initial gas (default: 1,000,000)
       - `:storage` — initial storage (default: empty)
+      - `:context` — execution context (default: empty context)
 
   ## Example
 
@@ -68,6 +71,7 @@ defmodule EEVM.MachineState do
       stack: Stack.new(),
       memory: Memory.new(),
       storage: Keyword.get(opts, :storage, Storage.new()),
+      context: Keyword.get(opts, :context, ExecutionContext.new()),
       gas: Keyword.get(opts, :gas, 1_000_000)
     }
   end

--- a/lib/eevm/opcodes.ex
+++ b/lib/eevm/opcodes.ex
@@ -50,6 +50,29 @@ defmodule EEVM.Opcodes do
   @shr 0x1C
   @sar 0x1D
 
+  # Environment opcodes (0x30–0x48)
+  @address 0x30
+  @balance 0x31
+  @origin 0x32
+  @caller 0x33
+  @callvalue 0x34
+  @calldataload 0x35
+  @calldatasize 0x36
+  @calldatacopy 0x37
+  @codesize 0x38
+  @gasprice 0x3A
+  @returndatasize 0x3D
+  @blockhash 0x40
+  @coinbase 0x41
+  @timestamp 0x42
+  @number 0x43
+  @prevrandao 0x44
+  @gaslimit 0x45
+  @chainid 0x46
+  @selfbalance 0x47
+  @basefee 0x48
+  @gas_ 0x5A
+
   # Memory operations (0x5_)
   @pop 0x50
   @mload 0x51
@@ -117,6 +140,29 @@ defmodule EEVM.Opcodes do
   def info(@shl), do: {:ok, %{name: "SHL", inputs: 2, outputs: 1}}
   def info(@shr), do: {:ok, %{name: "SHR", inputs: 2, outputs: 1}}
   def info(@sar), do: {:ok, %{name: "SAR", inputs: 2, outputs: 1}}
+
+  # Environment opcodes
+  def info(@address), do: {:ok, %{name: "ADDRESS", inputs: 0, outputs: 1}}
+  def info(@balance), do: {:ok, %{name: "BALANCE", inputs: 1, outputs: 1}}
+  def info(@origin), do: {:ok, %{name: "ORIGIN", inputs: 0, outputs: 1}}
+  def info(@caller), do: {:ok, %{name: "CALLER", inputs: 0, outputs: 1}}
+  def info(@callvalue), do: {:ok, %{name: "CALLVALUE", inputs: 0, outputs: 1}}
+  def info(@calldataload), do: {:ok, %{name: "CALLDATALOAD", inputs: 1, outputs: 1}}
+  def info(@calldatasize), do: {:ok, %{name: "CALLDATASIZE", inputs: 0, outputs: 1}}
+  def info(@calldatacopy), do: {:ok, %{name: "CALLDATACOPY", inputs: 3, outputs: 0}}
+  def info(@codesize), do: {:ok, %{name: "CODESIZE", inputs: 0, outputs: 1}}
+  def info(@gasprice), do: {:ok, %{name: "GASPRICE", inputs: 0, outputs: 1}}
+  def info(@returndatasize), do: {:ok, %{name: "RETURNDATASIZE", inputs: 0, outputs: 1}}
+  def info(@blockhash), do: {:ok, %{name: "BLOCKHASH", inputs: 1, outputs: 1}}
+  def info(@coinbase), do: {:ok, %{name: "COINBASE", inputs: 0, outputs: 1}}
+  def info(@timestamp), do: {:ok, %{name: "TIMESTAMP", inputs: 0, outputs: 1}}
+  def info(@number), do: {:ok, %{name: "NUMBER", inputs: 0, outputs: 1}}
+  def info(@prevrandao), do: {:ok, %{name: "PREVRANDAO", inputs: 0, outputs: 1}}
+  def info(@gaslimit), do: {:ok, %{name: "GASLIMIT", inputs: 0, outputs: 1}}
+  def info(@chainid), do: {:ok, %{name: "CHAINID", inputs: 0, outputs: 1}}
+  def info(@selfbalance), do: {:ok, %{name: "SELFBALANCE", inputs: 0, outputs: 1}}
+  def info(@basefee), do: {:ok, %{name: "BASEFEE", inputs: 0, outputs: 1}}
+  def info(@gas_), do: {:ok, %{name: "GAS", inputs: 0, outputs: 1}}
 
   def info(@pop), do: {:ok, %{name: "POP", inputs: 1, outputs: 0}}
   def info(@mload), do: {:ok, %{name: "MLOAD", inputs: 1, outputs: 1}}

--- a/test/eevm_test.exs
+++ b/test/eevm_test.exs
@@ -3,7 +3,7 @@ defmodule EEVMTest do
   import Bitwise
   doctest EEVM
 
-  alias EEVM.{Stack, Memory, Storage, Gas}
+  alias EEVM.{Stack, Memory, Storage, ExecutionContext, Gas}
 
   # ── Stack Tests ──────────────────────────────────────────────────────
 
@@ -572,6 +572,240 @@ defmodule EEVMTest do
       code = <<0x60, 42, 0x60, 0, 0x55, 0x00>>
       result = EEVM.execute(code)
       assert Storage.load(result.storage, 0) == 42
+    end
+  end
+
+  # ── Environment Opcode Tests ─────────────────────────────────────────
+
+  describe "Environment Opcodes" do
+    test "ADDRESS pushes current contract address" do
+      ctx = ExecutionContext.new(address: 0xCAFE)
+      # ADDRESS, STOP
+      code = <<0x30, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [0xCAFE]
+    end
+
+    test "CALLER pushes msg.sender" do
+      ctx = ExecutionContext.new(caller: 0xDEAD)
+      code = <<0x33, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [0xDEAD]
+    end
+
+    test "ORIGIN pushes tx.origin" do
+      ctx = ExecutionContext.new(origin: 0xBEEF)
+      code = <<0x32, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [0xBEEF]
+    end
+
+    test "CALLVALUE pushes msg.value" do
+      ctx = ExecutionContext.new(callvalue: 1_000_000)
+      code = <<0x34, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [1_000_000]
+    end
+
+    test "CALLDATASIZE pushes length of calldata" do
+      ctx = ExecutionContext.new(calldata: <<1, 2, 3, 4>>)
+      code = <<0x36, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [4]
+    end
+
+    test "CALLDATASIZE is 0 with no calldata" do
+      code = <<0x36, 0x00>>
+      result = EEVM.execute(code)
+      assert EEVM.stack_values(result) == [0]
+    end
+
+    test "CALLDATALOAD reads 32 bytes from calldata" do
+      # 32 bytes of calldata, load from offset 0
+      calldata = <<0::248, 42>>
+      ctx = ExecutionContext.new(calldata: calldata)
+      # PUSH1 0, CALLDATALOAD, STOP
+      code = <<0x60, 0, 0x35, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [42]
+    end
+
+    test "CALLDATALOAD pads with zeros past end" do
+      # 4 bytes of calldata, load from offset 0 — pads 28 zeros on right
+      calldata = <<0xFF, 0xFF, 0xFF, 0xFF>>
+      ctx = ExecutionContext.new(calldata: calldata)
+      code = <<0x60, 0, 0x35, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      expected = 0xFFFFFFFF00000000000000000000000000000000000000000000000000000000
+      assert EEVM.stack_values(result) == [expected]
+    end
+
+    test "CALLDATALOAD beyond calldata returns 0" do
+      ctx = ExecutionContext.new(calldata: <<1, 2>>)
+      code = <<0x60, 100, 0x35, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [0]
+    end
+
+    test "CALLDATACOPY copies calldata to memory" do
+      calldata = <<0xAA, 0xBB, 0xCC, 0xDD>>
+      ctx = ExecutionContext.new(calldata: calldata)
+      # PUSH1 4 (length), PUSH1 0 (data_offset), PUSH1 0 (dest_offset), CALLDATACOPY
+      # PUSH1 0, MLOAD, STOP
+      code = <<0x60, 4, 0x60, 0, 0x60, 0, 0x37, 0x60, 0, 0x51, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      # Memory word at 0: 0xAABBCCDD followed by 28 zero bytes
+      expected = 0xAABBCCDD00000000000000000000000000000000000000000000000000000000
+      assert EEVM.stack_values(result) == [expected]
+    end
+
+    test "CODESIZE pushes bytecode length" do
+      # CODESIZE, STOP — 2 bytes of code
+      code = <<0x38, 0x00>>
+      result = EEVM.execute(code)
+      assert EEVM.stack_values(result) == [2]
+    end
+
+    test "GASPRICE pushes tx gas price" do
+      ctx = ExecutionContext.new(gasprice: 20_000_000_000)
+      code = <<0x3A, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [20_000_000_000]
+    end
+
+    test "RETURNDATASIZE pushes 0 with no prior return" do
+      code = <<0x3D, 0x00>>
+      result = EEVM.execute(code)
+      assert EEVM.stack_values(result) == [0]
+    end
+
+    test "COINBASE pushes block producer address" do
+      ctx = ExecutionContext.new(block_coinbase: 0xABC)
+      code = <<0x41, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [0xABC]
+    end
+
+    test "TIMESTAMP pushes block timestamp" do
+      ctx = ExecutionContext.new(block_timestamp: 1_700_000_000)
+      code = <<0x42, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [1_700_000_000]
+    end
+
+    test "NUMBER pushes block number" do
+      ctx = ExecutionContext.new(block_number: 18_000_000)
+      code = <<0x43, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [18_000_000]
+    end
+
+    test "PREVRANDAO pushes previous block randao" do
+      ctx = ExecutionContext.new(block_prevrandao: 0xDEADBEEF)
+      code = <<0x44, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [0xDEADBEEF]
+    end
+
+    test "GASLIMIT pushes block gas limit" do
+      ctx = ExecutionContext.new(block_gaslimit: 30_000_000)
+      code = <<0x45, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [30_000_000]
+    end
+
+    test "CHAINID pushes chain ID (default 1 = mainnet)" do
+      code = <<0x46, 0x00>>
+      result = EEVM.execute(code)
+      assert EEVM.stack_values(result) == [1]
+    end
+
+    test "CHAINID with custom chain ID" do
+      ctx = ExecutionContext.new(block_chainid: 137)
+      code = <<0x46, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [137]
+    end
+
+    test "BASEFEE pushes block base fee" do
+      ctx = ExecutionContext.new(block_basefee: 30_000_000_000)
+      code = <<0x48, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [30_000_000_000]
+    end
+
+    test "BALANCE looks up address balance" do
+      ctx = ExecutionContext.new(balances: %{0xDEAD => 5_000_000})
+      # PUSH2 0xDEAD, BALANCE, STOP
+      code = <<0x61, 0xDE, 0xAD, 0x31, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [5_000_000]
+    end
+
+    test "BALANCE returns 0 for unknown address" do
+      code = <<0x61, 0xDE, 0xAD, 0x31, 0x00>>
+      result = EEVM.execute(code)
+      assert EEVM.stack_values(result) == [0]
+    end
+
+    test "SELFBALANCE pushes own contract balance" do
+      ctx = ExecutionContext.new(address: 0xCAFE, balances: %{0xCAFE => 999})
+      code = <<0x47, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [999]
+    end
+
+    test "BLOCKHASH returns hash for recent block" do
+      ctx =
+        ExecutionContext.new(
+          block_number: 100,
+          block_hashes: %{99 => 0xAAAA, 98 => 0xBBBB}
+        )
+
+      # PUSH1 99, BLOCKHASH, STOP
+      code = <<0x60, 99, 0x40, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [0xAAAA]
+    end
+
+    test "BLOCKHASH returns 0 for current or future block" do
+      ctx = ExecutionContext.new(block_number: 100)
+      # PUSH1 100, BLOCKHASH, STOP (current block → 0)
+      code = <<0x60, 100, 0x40, 0x00>>
+      result = EEVM.execute(code, context: ctx)
+      assert EEVM.stack_values(result) == [0]
+    end
+
+    test "GAS pushes remaining gas after deducting for GAS opcode" do
+      # GAS (0x5A), STOP
+      # GAS costs 2 gas, STOP costs 0
+      # So after GAS executes, gas_remaining = initial - 2
+      # The value pushed should be gas AFTER the GAS opcode's cost
+      code = <<0x5A, 0x00>>
+      result = EEVM.execute(code, gas: 1000)
+      # GAS pushes remaining gas (1000-2=998), then STOP costs 0
+      assert EEVM.stack_values(result) == [998]
+      assert result.gas == 998
+    end
+
+    test "env opcodes have correct gas costs" do
+      # ADDRESS costs 2 (base)
+      code = <<0x30, 0x00>>
+      result = EEVM.execute(code, gas: 1000)
+      assert result.gas == 1000 - 2
+    end
+
+    test "BALANCE costs 2600 gas" do
+      code = <<0x60, 0, 0x31, 0x00>>
+      result = EEVM.execute(code, gas: 10_000)
+      # PUSH1=3 + BALANCE=2600 + STOP=0 = 2603
+      assert result.gas == 10_000 - 2603
+    end
+
+    test "SELFBALANCE costs 5 gas" do
+      code = <<0x47, 0x00>>
+      result = EEVM.execute(code, gas: 1000)
+      assert result.gas == 1000 - 5
     end
   end
 end


### PR DESCRIPTION
Implements the EVM's Host/Environment interface — how the VM reads external information about the transaction, caller, and block.

- New EEVM.ExecutionContext struct with message context (address, caller, origin, callvalue, calldata, gasprice), block context (number, timestamp, coinbase, gaslimit, prevrandao, basefee, chainid), account balances, and block hashes
- MachineState now carries an ExecutionContext, configurable via opts
- 22 new opcodes implemented: ADDRESS, BALANCE, ORIGIN, CALLER, CALLVALUE, CALLDATALOAD, CALLDATASIZE, CALLDATACOPY, CODESIZE, GASPRICE, RETURNDATASIZE, BLOCKHASH, COINBASE, TIMESTAMP, NUMBER, PREVRANDAO, GASLIMIT, CHAINID, SELFBALANCE, BASEFEE, GAS
- Correct gas costs: base=2, BALANCE=2600, SELFBALANCE=5, BLOCKHASH=20, CALLDATALOAD=3, CALLDATACOPY=3+mem expansion
- CALLDATALOAD right-pads with zeros past calldata end (per spec)
- BLOCKHASH only returns hashes for the last 256 blocks
- 30 new tests covering all opcodes, edge cases, and gas costs