### PR TITLE
Add LOG0–LOG4 event logging opcodes

### DIFF
--- a/lib/eevm.ex
+++ b/lib/eevm.ex
@@ -34,7 +34,7 @@ defmodule EEVM do
   - **Typespecs** — `@spec` annotations for documentation and Dialyzer
   """
 
-  alias EEVM.{Executor, Stack}
+  alias EEVM.{Executor, MachineState, Stack}
 
   @doc """
   Executes EVM bytecode and returns the final machine state.
@@ -62,6 +62,10 @@ defmodule EEVM do
   def stack_values(state) do
     Stack.to_list(state.stack)
   end
+
+  @doc "Returns the list of logs emitted during execution."
+  @spec logs(MachineState.t()) :: [map()]
+  def logs(%MachineState{} = state), do: state.logs
 
   @doc """
   Disassembles bytecode into a human-readable list of instructions.

--- a/lib/eevm/executor.ex
+++ b/lib/eevm/executor.ex
@@ -41,6 +41,7 @@ defmodule EEVM.Executor do
     ControlFlow,
     Crypto,
     Environment,
+    Logging,
     StackMemoryStorage,
     System
   }
@@ -131,6 +132,7 @@ defmodule EEVM.Executor do
   defp execute_opcode(op, state) when op in 0x56..0x5B, do: ControlFlow.execute(op, state)
   defp execute_opcode(0x5F, state), do: ControlFlow.execute(0x5F, state)
   defp execute_opcode(op, state) when op in 0x60..0x9F, do: ControlFlow.execute(op, state)
+  defp execute_opcode(op, state) when op in 0xA0..0xA4, do: Logging.execute(op, state)
   defp execute_opcode(0xF3, state), do: System.execute(0xF3, state)
   defp execute_opcode(0xFD, state), do: System.execute(0xFD, state)
   defp execute_opcode(0xFE, state), do: System.execute(0xFE, state)

--- a/lib/eevm/gas.ex
+++ b/lib/eevm/gas.ex
@@ -51,6 +51,9 @@ defmodule EEVM.Gas do
   @gas_blockhash 20
   @gas_balance 2600
   @gas_selfbalance 5
+  @gas_log 375
+  @gas_log_topic 375
+  @gas_log_data 8
 
   @doc """
   Returns the static gas cost for a given opcode byte.
@@ -215,6 +218,8 @@ defmodule EEVM.Gas do
   # SWAP1–SWAP16 (0x90–0x9F)
   def static_cost(op) when op >= 0x90 and op <= 0x9F, do: @gas_very_low
 
+  def static_cost(op) when op in 0xA0..0xA4, do: @gas_log
+
   # System (0xF3, 0xFD, 0xFE)
   # RETURN (+ memory expansion)
   def static_cost(0xF3), do: @gas_zero
@@ -257,6 +262,11 @@ defmodule EEVM.Gas do
   @doc "Dynamic gas for copy operations: 3 gas per 32-byte word (ceiling)."
   @spec copy_cost(non_neg_integer()) :: non_neg_integer()
   def copy_cost(size), do: div(size + 31, 32) * @gas_copy
+
+  @doc "Dynamic gas for LOGn: base + per-topic + per-byte-of-data."
+  @spec log_cost(non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  def log_cost(topic_count, data_size),
+    do: @gas_log + @gas_log_topic * topic_count + @gas_log_data * data_size
 
   @doc """
   Calculates the gas cost of memory expansion.

--- a/lib/eevm/machine_state.ex
+++ b/lib/eevm/machine_state.ex
@@ -37,6 +37,7 @@ defmodule EEVM.MachineState do
           gas: non_neg_integer(),
           status: status(),
           return_data: binary(),
+          logs: [%{address: non_neg_integer(), data: binary(), topics: [non_neg_integer()]}],
           code: binary()
         }
 
@@ -51,6 +52,7 @@ defmodule EEVM.MachineState do
             gas: 1_000_000,
             status: :running,
             return_data: <<>>,
+            logs: [],
             code: <<>>
 
   @doc """

--- a/lib/eevm/opcodes.ex
+++ b/lib/eevm/opcodes.ex
@@ -103,6 +103,12 @@ defmodule EEVM.Opcodes do
   @swap1 0x90
   @swap16 0x9F
 
+  @log0 0xA0
+  @log1 0xA1
+  @log2 0xA2
+  @log3 0xA3
+  @log4 0xA4
+
   # System operations
   @return_ 0xF3
   @revert 0xFD
@@ -185,6 +191,12 @@ defmodule EEVM.Opcodes do
   def info(@jumpi), do: {:ok, %{name: "JUMPI", inputs: 2, outputs: 0}}
   def info(@pc), do: {:ok, %{name: "PC", inputs: 0, outputs: 1}}
   def info(@jumpdest), do: {:ok, %{name: "JUMPDEST", inputs: 0, outputs: 0}}
+
+  def info(@log0), do: {:ok, %{name: "LOG0", inputs: 2, outputs: 0}}
+  def info(@log1), do: {:ok, %{name: "LOG1", inputs: 3, outputs: 0}}
+  def info(@log2), do: {:ok, %{name: "LOG2", inputs: 4, outputs: 0}}
+  def info(@log3), do: {:ok, %{name: "LOG3", inputs: 5, outputs: 0}}
+  def info(@log4), do: {:ok, %{name: "LOG4", inputs: 6, outputs: 0}}
 
   def info(@return_), do: {:ok, %{name: "RETURN", inputs: 2, outputs: 0}}
   def info(@revert), do: {:ok, %{name: "REVERT", inputs: 2, outputs: 0}}

--- a/lib/eevm/opcodes/logging.ex
+++ b/lib/eevm/opcodes/logging.ex
@@ -1,0 +1,72 @@
+defmodule EEVM.Opcodes.Logging do
+  @moduledoc """
+  EVM logging opcodes — LOG0 through LOG4.
+
+  ## EVM Concepts
+
+  - LOG instructions emit event logs that are stored in transaction receipts.
+  - Each log contains the emitting contract address, a data payload from memory,
+    and 0–4 indexed topic values from the stack.
+  - Topics are 256-bit values used for efficient off-chain filtering (e.g. event signatures).
+  - Gas cost: 375 base + 375 per topic + 8 per byte of data + memory expansion.
+
+  ## Elixir Learning Notes
+
+  - We use pattern matching on the topic count (0–4) to dispatch LOG variants.
+  - Logs accumulate in `state.logs` as a list of maps, preserving insertion order.
+  - `binary_part/3` extracts a slice from a binary — used to read log data from memory bytes.
+  """
+
+  alias EEVM.{Gas, MachineState, Memory, Stack}
+
+  @doc """
+  Dispatches a LOG opcode (LOG0–LOG4) to the matching topic-count handler.
+  """
+  @spec execute(non_neg_integer(), MachineState.t()) ::
+          {:ok, MachineState.t()} | {:error, atom(), MachineState.t()}
+  def execute(0xA0, state), do: execute_log(state, 0)
+  def execute(0xA1, state), do: execute_log(state, 1)
+  def execute(0xA2, state), do: execute_log(state, 2)
+  def execute(0xA3, state), do: execute_log(state, 3)
+  def execute(0xA4, state), do: execute_log(state, 4)
+
+  def execute(_opcode, state), do: {:ok, MachineState.halt(state, :invalid)}
+
+  defp execute_log(state, topic_count) do
+    with {:ok, offset, s1} <- Stack.pop(state.stack),
+         {:ok, size, s2} <- Stack.pop(s1),
+         {:ok, topics, s3} <- pop_topics(s2, topic_count, []) do
+      dynamic_cost =
+        Gas.log_cost(topic_count, size) +
+          Gas.memory_expansion_cost(Memory.size(state.memory), offset, size)
+
+      case MachineState.consume_gas(%{state | stack: s3}, dynamic_cost) do
+        {:ok, s4} ->
+          {data, new_memory} = Memory.read_bytes(s4.memory, offset, size)
+
+          log_entry = %{
+            address: s4.contract.address,
+            data: data,
+            topics: topics
+          }
+
+          s5 = %{s4 | memory: new_memory, logs: s4.logs ++ [log_entry]}
+          {:ok, MachineState.advance_pc(s5)}
+
+        {:error, :out_of_gas, halted_state} ->
+          {:error, :out_of_gas, halted_state}
+      end
+    else
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
+  defp pop_topics(stack, 0, acc), do: {:ok, Enum.reverse(acc), stack}
+
+  defp pop_topics(stack, n, acc) do
+    case Stack.pop(stack) do
+      {:ok, value, new_stack} -> pop_topics(new_stack, n - 1, [value | acc])
+      error -> error
+    end
+  end
+end

--- a/test/opcodes/logging_test.exs
+++ b/test/opcodes/logging_test.exs
@@ -1,0 +1,144 @@
+defmodule EEVM.Opcodes.LoggingTest do
+  use ExUnit.Case, async: true
+
+  alias EEVM.Context.Contract
+  alias EEVM.Gas
+
+  describe "LOG opcodes" do
+    # ── LOG0–LOG4 Tests ──────
+
+    test "LOG0 empty data (0-byte log, no topics)" do
+      code = <<0x60, 0x00, 0x60, 0x00, 0xA0, 0x00>>
+      result = EEVM.execute(code)
+
+      assert EEVM.logs(result) == [%{address: 0, data: <<>>, topics: []}]
+    end
+
+    test "LOG0 with data reads memory bytes" do
+      code =
+        <<
+          0x60,
+          0xAA,
+          0x60,
+          0x00,
+          0x53,
+          0x60,
+          0xBB,
+          0x60,
+          0x01,
+          0x53,
+          0x60,
+          0xCC,
+          0x60,
+          0x02,
+          0x53,
+          0x60,
+          0x03,
+          0x60,
+          0x00,
+          0xA0,
+          0x00
+        >>
+
+      result = EEVM.execute(code)
+      assert EEVM.logs(result) == [%{address: 0, data: <<0xAA, 0xBB, 0xCC>>, topics: []}]
+    end
+
+    test "LOG1 single topic" do
+      code = <<0x60, 0x2A, 0x60, 0x00, 0x60, 0x00, 0xA1, 0x00>>
+      result = EEVM.execute(code)
+
+      assert EEVM.logs(result) == [%{address: 0, data: <<>>, topics: [0x2A]}]
+    end
+
+    test "LOG2 two topics" do
+      code = <<0x60, 0x22, 0x60, 0x11, 0x60, 0x00, 0x60, 0x00, 0xA2, 0x00>>
+      result = EEVM.execute(code)
+
+      assert EEVM.logs(result) == [%{address: 0, data: <<>>, topics: [0x11, 0x22]}]
+    end
+
+    test "LOG3 three topics" do
+      code = <<0x60, 0x03, 0x60, 0x02, 0x60, 0x01, 0x60, 0x00, 0x60, 0x00, 0xA3, 0x00>>
+      result = EEVM.execute(code)
+
+      assert EEVM.logs(result) == [%{address: 0, data: <<>>, topics: [0x01, 0x02, 0x03]}]
+    end
+
+    test "LOG4 four topics" do
+      code =
+        <<
+          0x60,
+          0x04,
+          0x60,
+          0x03,
+          0x60,
+          0x02,
+          0x60,
+          0x01,
+          0x60,
+          0x00,
+          0x60,
+          0x00,
+          0xA4,
+          0x00
+        >>
+
+      result = EEVM.execute(code)
+      assert EEVM.logs(result) == [%{address: 0, data: <<>>, topics: [0x01, 0x02, 0x03, 0x04]}]
+    end
+
+    test "multiple LOGs accumulate in state.logs list" do
+      code =
+        <<
+          0x60,
+          0xAA,
+          0x60,
+          0x00,
+          0x53,
+          0x60,
+          0x01,
+          0x60,
+          0x00,
+          0xA0,
+          0x60,
+          0x99,
+          0x60,
+          0x00,
+          0x60,
+          0x00,
+          0xA1,
+          0x00
+        >>
+
+      result = EEVM.execute(code)
+
+      assert EEVM.logs(result) == [
+               %{address: 0, data: <<0xAA>>, topics: []},
+               %{address: 0, data: <<>>, topics: [0x99]}
+             ]
+    end
+
+    test "gas calculation for LOGn is 375 + 375*N + 8*size" do
+      assert Gas.log_cost(0, 0) == 375
+      assert Gas.log_cost(2, 10) == 375 + 375 * 2 + 8 * 10
+      assert Gas.log_cost(4, 64) == 375 + 375 * 4 + 8 * 64
+    end
+
+    test "memory expansion is triggered by LOG data reads beyond current memory" do
+      code = <<0x60, 0x40, 0x60, 0x00, 0xA0, 0x00>>
+      result = EEVM.execute(code)
+
+      assert result.memory.size == 64
+      assert [%{data: data}] = EEVM.logs(result)
+      assert byte_size(data) == 64
+    end
+
+    test "contract address is attached to emitted logs" do
+      code = <<0x60, 0x00, 0x60, 0x00, 0xA0, 0x00>>
+      result = EEVM.execute(code, contract: Contract.new(address: 0xCAFE))
+
+      assert EEVM.logs(result) == [%{address: 0xCAFE, data: <<>>, topics: []}]
+    end
+  end
+end


### PR DESCRIPTION
Implements the five LOG opcodes (0xA0-0xA4) for emitting events. Each pops a memory region and N topic words off the stack, charges 375 + 375*topics + 8*data_bytes gas, reads the data from memory, and appends a log entry to the machine state. Logs are accessible via EEVM.logs/1 after execution.

Closes #9