### PR TITLE
Add RETURNDATACOPY opcode

### DIFF
--- a/lib/eevm/executor.ex
+++ b/lib/eevm/executor.ex
@@ -121,7 +121,7 @@ defmodule EEVM.Executor do
   defp execute_opcode(op, state) when op in 0x10..0x15, do: Comparison.execute(op, state)
   defp execute_opcode(op, state) when op in 0x16..0x1D, do: Bitwise.execute(op, state)
   defp execute_opcode(0x20, state), do: Crypto.execute(0x20, state)
-  defp execute_opcode(op, state) when op in 0x30..0x3D, do: Environment.execute(op, state)
+  defp execute_opcode(op, state) when op in 0x30..0x3E, do: Environment.execute(op, state)
   defp execute_opcode(op, state) when op in 0x40..0x48, do: Environment.execute(op, state)
   defp execute_opcode(0x50, state), do: StackMemoryStorage.execute(0x50, state)
   defp execute_opcode(op, state) when op in 0x51..0x55, do: StackMemoryStorage.execute(op, state)

--- a/lib/eevm/gas.ex
+++ b/lib/eevm/gas.ex
@@ -154,6 +154,7 @@ defmodule EEVM.Gas do
   def static_cost(0x3A), do: @gas_base
   # RETURNDATASIZE
   def static_cost(0x3D), do: @gas_base
+  def static_cost(0x3E), do: @gas_very_low
   # BLOCKHASH
   def static_cost(0x40), do: @gas_blockhash
   # COINBASE

--- a/lib/eevm/machine_state.ex
+++ b/lib/eevm/machine_state.ex
@@ -81,6 +81,7 @@ defmodule EEVM.MachineState do
       tx: Keyword.get(opts, :tx, Transaction.new()),
       block: Keyword.get(opts, :block, Block.new()),
       contract: Keyword.get(opts, :contract, Contract.new()),
+      return_data: Keyword.get(opts, :return_data, <<>>),
       gas: Keyword.get(opts, :gas, 1_000_000)
     }
   end

--- a/lib/eevm/opcodes.ex
+++ b/lib/eevm/opcodes.ex
@@ -65,6 +65,7 @@ defmodule EEVM.Opcodes do
   @codesize 0x38
   @gasprice 0x3A
   @returndatasize 0x3D
+  @returndatacopy 0x3E
   @blockhash 0x40
   @coinbase 0x41
   @timestamp 0x42
@@ -155,6 +156,7 @@ defmodule EEVM.Opcodes do
   def info(@calldataload), do: {:ok, %{name: "CALLDATALOAD", inputs: 1, outputs: 1}}
   def info(@calldatasize), do: {:ok, %{name: "CALLDATASIZE", inputs: 0, outputs: 1}}
   def info(@calldatacopy), do: {:ok, %{name: "CALLDATACOPY", inputs: 3, outputs: 0}}
+  def info(@returndatacopy), do: {:ok, %{name: "RETURNDATACOPY", inputs: 3, outputs: 0}}
   def info(@codesize), do: {:ok, %{name: "CODESIZE", inputs: 0, outputs: 1}}
   def info(@gasprice), do: {:ok, %{name: "GASPRICE", inputs: 0, outputs: 1}}
   def info(@returndatasize), do: {:ok, %{name: "RETURNDATASIZE", inputs: 0, outputs: 1}}

--- a/lib/eevm/opcodes/environment.ex
+++ b/lib/eevm/opcodes/environment.ex
@@ -137,6 +137,45 @@ defmodule EEVM.Opcodes.Environment do
   def execute(0x3A, state), do: Helpers.push_value(state, state.tx.gasprice)
   def execute(0x3D, state), do: Helpers.push_value(state, byte_size(state.return_data))
 
+  def execute(0x3E, state) do
+    with {:ok, dest_offset, s1} <- Stack.pop(state.stack),
+         {:ok, data_offset, s2} <- Stack.pop(s1),
+         {:ok, length, s3} <- Stack.pop(s2) do
+      cond do
+        length == 0 ->
+          {:ok, MachineState.advance_pc(%{state | stack: s3})}
+
+        data_offset + length > byte_size(state.return_data) ->
+          {:ok, MachineState.halt(%{state | stack: s3}, :reverted)}
+
+        true ->
+          dynamic_cost =
+            Gas.copy_cost(length) +
+              Gas.memory_expansion_cost(Memory.size(state.memory), dest_offset, length)
+
+          case MachineState.consume_gas(%{state | stack: s3}, dynamic_cost) do
+            {:ok, s4} ->
+              bytes = binary_part(s4.return_data, data_offset, length)
+
+              new_memory =
+                bytes
+                |> :binary.bin_to_list()
+                |> Enum.with_index()
+                |> Enum.reduce(s4.memory, fn {byte, i}, mem ->
+                  Memory.store_byte(mem, dest_offset + i, byte)
+                end)
+
+              {:ok, MachineState.advance_pc(%{s4 | memory: new_memory})}
+
+            {:error, :out_of_gas, halted_state} ->
+              {:error, :out_of_gas, halted_state}
+          end
+      end
+    else
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
   # BLOCKHASH — returns the hash of a past block by number.
   # Only the 256 most recent blocks are available. Anything older — or the
   # current block itself — returns 0. The lookup is delegated to Block.hash/2.

--- a/test/opcodes/environment_test.exs
+++ b/test/opcodes/environment_test.exs
@@ -2,6 +2,7 @@ defmodule EEVM.Opcodes.EnvironmentTest do
   use ExUnit.Case, async: true
 
   alias EEVM.Context.{Transaction, Block, Contract}
+  alias EEVM.Gas
 
   describe "Environment Opcodes" do
     test "ADDRESS pushes current contract address" do
@@ -232,6 +233,74 @@ defmodule EEVM.Opcodes.EnvironmentTest do
       code = <<0x47, 0x00>>
       result = EEVM.execute(code, gas: 1000)
       assert result.gas == 1000 - 5
+    end
+  end
+
+  describe "RETURNDATACOPY (0x3E)" do
+    test "copies return data to memory" do
+      return_data = <<0xAA, 0xBB, 0xCC, 0xDD>>
+      code = <<0x60, 4, 0x60, 0, 0x60, 0, 0x3E, 0x60, 0, 0x51, 0x00>>
+
+      result = EEVM.execute(code, return_data: return_data)
+
+      expected = 0xAABBCCDD00000000000000000000000000000000000000000000000000000000
+      assert EEVM.stack_values(result) == [expected]
+    end
+
+    test "reverts on out-of-bounds read" do
+      return_data = <<0xAA, 0xBB>>
+      code = <<0x60, 2, 0x60, 1, 0x60, 0, 0x3E, 0x00>>
+
+      result = EEVM.execute(code, return_data: return_data)
+
+      assert result.status == :reverted
+    end
+
+    test "zero-length copy is a no-op" do
+      return_data = <<0xAA, 0xBB>>
+      code = <<0x60, 0, 0x60, 250, 0x60, 10, 0x3E, 0x59, 0x00>>
+
+      result = EEVM.execute(code, return_data: return_data)
+
+      assert result.status == :stopped
+      assert EEVM.stack_values(result) == [0]
+    end
+
+    test "copies from middle of return data" do
+      return_data = <<0x11, 0x22, 0x33, 0x44, 0x55>>
+      code = <<0x60, 2, 0x60, 2, 0x60, 0, 0x3E, 0x60, 0, 0x51, 0x00>>
+
+      result = EEVM.execute(code, return_data: return_data)
+
+      expected = :binary.decode_unsigned(<<0x33, 0x44, 0::240>>)
+      assert EEVM.stack_values(result) == [expected]
+    end
+
+    test "gas calculation includes static, copy, and memory expansion" do
+      return_data = <<0xAA, 0xBB, 0xCC, 0xDD>>
+      code = <<0x60, 4, 0x60, 0, 0x60, 0, 0x3E, 0x60, 0, 0x51, 0x00>>
+      initial_gas = 1_000
+
+      result = EEVM.execute(code, gas: initial_gas, return_data: return_data)
+
+      expected_spent =
+        Gas.static_cost(0x60) * 4 +
+          Gas.static_cost(0x3E) +
+          Gas.copy_cost(4) +
+          Gas.memory_expansion_cost(0, 0, 4) +
+          Gas.static_cost(0x51)
+
+      assert result.gas == initial_gas - expected_spent
+    end
+
+    test "partial copy with destination offset" do
+      return_data = <<0xAA, 0xBB>>
+      code = <<0x60, 2, 0x60, 0, 0x60, 1, 0x3E, 0x60, 0, 0x51, 0x00>>
+
+      result = EEVM.execute(code, return_data: return_data)
+
+      expected = :binary.decode_unsigned(<<0x00, 0xAA, 0xBB, 0::232>>)
+      assert EEVM.stack_values(result) == [expected]
     end
   end
 end


### PR DESCRIPTION
## Summary
- Implement RETURNDATACOPY opcode (0x3E) — copies return data buffer into memory
- Companion to the existing RETURNDATASIZE (0x3D) opcode
- Correctly reverts on out-of-bounds access (unlike CALLDATACOPY which zero-pads)

## Changes
- **`opcodes.ex`**: Added RETURNDATACOPY definition (inputs: 3, outputs: 0)
- **`gas.ex`**: Added `copy_cost/1` helper (`3 * ceil(size/32)`) and static cost entry for 0x3E
- **`executor.ex`**: Implemented `execute_opcode(0x3E, state)` — pops dest_offset/offset/size, bounds-checks against return_data length, copies bytes to memory
- **`machine_state.ex`**: Added `:return_data` option support in `new/2` for testability

## Key Behavior
- **Reverts** if `offset + size > byte_size(return_data)` — this is the critical difference from CALLDATACOPY
- Zero-size copy is a no-op (succeeds even with empty return_data)

## Tests
6 new tests covering basic copy, out-of-bounds revert, zero-size, middle offset, gas calculation, and partial copy.

Closes #12