### PR TITLE
Add MCOPY memory copy opcode (EIP-5656)

### DIFF
--- a/lib/eevm/executor.ex
+++ b/lib/eevm/executor.ex
@@ -126,6 +126,7 @@ defmodule EEVM.Executor do
   defp execute_opcode(0x50, state), do: StackMemoryStorage.execute(0x50, state)
   defp execute_opcode(op, state) when op in 0x51..0x55, do: StackMemoryStorage.execute(op, state)
   defp execute_opcode(0x59, state), do: StackMemoryStorage.execute(0x59, state)
+  defp execute_opcode(0x5E, state), do: StackMemoryStorage.execute(0x5E, state)
   defp execute_opcode(0x5A, state), do: Environment.execute(0x5A, state)
   defp execute_opcode(op, state) when op in 0x56..0x5B, do: ControlFlow.execute(op, state)
   defp execute_opcode(0x5F, state), do: ControlFlow.execute(0x5F, state)

--- a/lib/eevm/gas.ex
+++ b/lib/eevm/gas.ex
@@ -44,6 +44,7 @@ defmodule EEVM.Gas do
   @gas_exp_byte 50
   @gas_keccak256 30
   @gas_keccak256_word 6
+  @gas_copy 3
   @gas_memory 3
   @gas_sload 200
   @gas_sstore 20_000
@@ -191,6 +192,7 @@ defmodule EEVM.Gas do
   def static_cost(0x58), do: @gas_base
   # MSIZE
   def static_cost(0x59), do: @gas_base
+  def static_cost(0x5E), do: @gas_very_low
   # JUMPDEST
   def static_cost(0x5B), do: @gas_jumpdest
 
@@ -250,6 +252,10 @@ defmodule EEVM.Gas do
     words = word_count(size)
     @gas_keccak256_word * words
   end
+
+  @doc "Dynamic gas for copy operations: 3 gas per 32-byte word (ceiling)."
+  @spec copy_cost(non_neg_integer()) :: non_neg_integer()
+  def copy_cost(size), do: div(size + 31, 32) * @gas_copy
 
   @doc """
   Calculates the gas cost of memory expansion.

--- a/lib/eevm/memory.ex
+++ b/lib/eevm/memory.ex
@@ -105,6 +105,26 @@ defmodule EEVM.Memory do
 
   def read_bytes(memory, _offset, 0), do: {<<>>, memory}
 
+  @doc """
+  Copies `length` bytes from `src` to `dst` within memory (memmove semantics).
+
+  This is the MCOPY operation (EIP-5656). Handles overlapping regions correctly
+  by reading all source bytes before writing — similar to C's `memmove`.
+  """
+  @spec copy(t(), non_neg_integer(), non_neg_integer(), non_neg_integer()) :: t()
+  def copy(memory, _dst, _src, 0), do: memory
+
+  def copy(%__MODULE__{} = memory, dst, src, length) do
+    {bytes, memory_after_read} = read_bytes(memory, src, length)
+
+    bytes
+    |> :binary.bin_to_list()
+    |> Enum.with_index()
+    |> Enum.reduce(memory_after_read, fn {byte, i}, acc ->
+      store_byte(acc, dst + i, byte)
+    end)
+  end
+
   @doc "Returns the current memory size in bytes (always a multiple of 32)."
   @spec size(t()) :: non_neg_integer()
   def size(%__MODULE__{size: size}), do: size

--- a/lib/eevm/opcodes.ex
+++ b/lib/eevm/opcodes.ex
@@ -84,6 +84,7 @@ defmodule EEVM.Opcodes do
   @sload 0x54
   @sstore 0x55
   @msize 0x59
+  @mcopy 0x5E
   @jump 0x56
   @jumpi 0x57
   @pc 0x58
@@ -177,6 +178,7 @@ defmodule EEVM.Opcodes do
   def info(@sload), do: {:ok, %{name: "SLOAD", inputs: 1, outputs: 1}}
   def info(@sstore), do: {:ok, %{name: "SSTORE", inputs: 2, outputs: 0}}
   def info(@msize), do: {:ok, %{name: "MSIZE", inputs: 0, outputs: 1}}
+  def info(@mcopy), do: {:ok, %{name: "MCOPY", inputs: 3, outputs: 0}}
   def info(@jump), do: {:ok, %{name: "JUMP", inputs: 1, outputs: 0}}
   def info(@jumpi), do: {:ok, %{name: "JUMPI", inputs: 2, outputs: 0}}
   def info(@pc), do: {:ok, %{name: "PC", inputs: 0, outputs: 1}}

--- a/lib/eevm/opcodes/stack_memory_storage.ex
+++ b/lib/eevm/opcodes/stack_memory_storage.ex
@@ -151,5 +151,30 @@ defmodule EEVM.Opcodes.StackMemoryStorage do
     Helpers.push_value(state, size)
   end
 
+  def execute(0x5E, state) do
+    with {:ok, dst, s1} <- Stack.pop(state.stack),
+         {:ok, src, s2} <- Stack.pop(s1),
+         {:ok, length, s3} <- Stack.pop(s2) do
+      if length == 0 do
+        {:ok, MachineState.advance_pc(%{state | stack: s3})}
+      else
+        max_offset = max(src + length, dst + length)
+        expansion_cost = Gas.memory_expansion_cost(Memory.size(state.memory), 0, max_offset)
+        dynamic_cost = Gas.copy_cost(length) + expansion_cost
+
+        case MachineState.consume_gas(%{state | stack: s3}, dynamic_cost) do
+          {:ok, s4} ->
+            new_memory = Memory.copy(s4.memory, dst, src, length)
+            {:ok, MachineState.advance_pc(%{s4 | memory: new_memory})}
+
+          {:error, :out_of_gas, halted_state} ->
+            {:error, :out_of_gas, halted_state}
+        end
+      end
+    else
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
   def execute(_opcode, state), do: {:ok, MachineState.halt(state, :invalid)}
 end

--- a/test/opcodes/stack_memory_test.exs
+++ b/test/opcodes/stack_memory_test.exs
@@ -1,6 +1,8 @@
 defmodule EEVM.Opcodes.StackMemoryTest do
   use ExUnit.Case, async: true
 
+  alias EEVM.Gas
+
   describe "Executor - Memory" do
     test "MSTORE and MLOAD" do
       # PUSH1 0xFF, PUSH1 0, MSTORE, PUSH1 0, MLOAD, STOP
@@ -16,4 +18,126 @@ defmodule EEVM.Opcodes.StackMemoryTest do
       assert EEVM.stack_values(result) == [32]
     end
   end
+
+  # ── MCOPY Tests (EIP-5656) ──────
+  describe "MCOPY (EIP-5656)" do
+    test "non-overlapping copy" do
+      code =
+        IO.iodata_to_binary([
+          mstore8(0, 0xAA),
+          mstore8(1, 0xBB),
+          mstore8(2, 0xCC),
+          mstore8(3, 0xDD),
+          mcopy(32, 0, 4),
+          mload(32),
+          <<0x00>>
+        ])
+
+      result = EEVM.execute(code)
+      [word] = EEVM.stack_values(result)
+
+      assert bytes32(word) |> Enum.take(4) == [0xAA, 0xBB, 0xCC, 0xDD]
+    end
+
+    test "overlapping forward copy uses memmove semantics" do
+      code =
+        IO.iodata_to_binary([
+          mstore8(0, 0x11),
+          mstore8(1, 0x22),
+          mstore8(2, 0x33),
+          mstore8(3, 0x44),
+          mcopy(1, 0, 3),
+          mload(0),
+          <<0x00>>
+        ])
+
+      result = EEVM.execute(code)
+      [word] = EEVM.stack_values(result)
+
+      assert bytes32(word) |> Enum.take(4) == [0x11, 0x11, 0x22, 0x33]
+    end
+
+    test "overlapping backward copy uses memmove semantics" do
+      code =
+        IO.iodata_to_binary([
+          mstore8(0, 0x11),
+          mstore8(1, 0x22),
+          mstore8(2, 0x33),
+          mstore8(3, 0x44),
+          mcopy(0, 1, 3),
+          mload(0),
+          <<0x00>>
+        ])
+
+      result = EEVM.execute(code)
+      [word] = EEVM.stack_values(result)
+
+      assert bytes32(word) |> Enum.take(4) == [0x22, 0x33, 0x44, 0x44]
+    end
+
+    test "zero-length copy is a no-op and keeps msize unchanged" do
+      code =
+        IO.iodata_to_binary([
+          mstore8(0, 0xAA),
+          <<0x59>>,
+          mcopy(0, 0, 0),
+          <<0x59, 0x00>>
+        ])
+
+      result = EEVM.execute(code)
+      assert EEVM.stack_values(result) == [32, 32]
+    end
+
+    test "gas calculation includes static, copy words, and memory expansion" do
+      code = IO.iodata_to_binary([mcopy(64, 0, 33), <<0x00>>])
+      result = EEVM.execute(code, gas: 100_000)
+
+      expected =
+        3 + 3 + 3 + Gas.static_cost(0x5E) + Gas.copy_cost(33) +
+          Gas.memory_expansion_cost(0, 0, 97)
+
+      assert result.status == :stopped
+      assert result.gas == 100_000 - expected
+    end
+
+    test "memory expansion covers both src and dst ranges" do
+      code = IO.iodata_to_binary([mcopy(0, 96, 32), <<0x59, 0x00>>])
+      result = EEVM.execute(code)
+      assert EEVM.stack_values(result) == [128]
+    end
+
+    test "large copy across word boundaries" do
+      writes =
+        for i <- 0..39 do
+          mstore8(i, i + 1)
+        end
+
+      code =
+        IO.iodata_to_binary([
+          writes,
+          mcopy(64, 0, 40),
+          mload(96),
+          mload(64),
+          <<0x00>>
+        ])
+
+      result = EEVM.execute(code)
+      [word1, word2] = EEVM.stack_values(result)
+
+      assert bytes32(word1) == Enum.to_list(1..32)
+      assert bytes32(word2) |> Enum.take(8) == Enum.to_list(33..40)
+      assert bytes32(word2) |> Enum.drop(8) == List.duplicate(0, 24)
+    end
+  end
+
+  defp push1(value), do: <<0x60, value>>
+
+  defp mstore8(offset, byte), do: IO.iodata_to_binary([push1(byte), push1(offset), <<0x53>>])
+
+  defp mcopy(dst, src, length),
+    do: IO.iodata_to_binary([push1(length), push1(src), push1(dst), <<0x5E>>])
+
+  defp mload(offset), do: IO.iodata_to_binary([push1(offset), <<0x51>>])
+
+  defp bytes32(word), do: :binary.bin_to_list(<<word::unsigned-big-integer-size(256)>>)
 end


### PR DESCRIPTION
## Summary
- Implement MCOPY opcode (0x5E) from the Cancun hard fork (EIP-5656)
- Memory-to-memory copy with correct overlapping region handling (memmove semantics)
- Add `Memory.copy/4` function to the Memory module

## Changes
- **`opcodes.ex`**: Added MCOPY definition (inputs: 3, outputs: 0)
- **`gas.ex`**: Added static cost for 0x5E and `copy_cost/1` helper
- **`memory.ex`**: Added `Memory.copy/4` — snapshots source bytes first, then writes to destination (handles overlap correctly)
- **`executor.ex`**: Implemented `execute_opcode(0x5E, state)` — pops dst/src/length, expands memory for both regions, charges dynamic gas, executes copy

## Key Behavior
- Handles overlapping src/dst regions correctly (memmove, not memcpy)
- Zero-length copy is a no-op (still consumes static gas)
- Memory expansion covers both source and destination regions

## Tests
7 new tests covering non-overlapping copy, overlapping forward/backward, zero-length, gas calculation, memory expansion, and cross-word-boundary copy.

Closes #13