### PR TITLE
Implement CODECOPY opcode

### DIFF
--- a/lib/eevm/gas.ex
+++ b/lib/eevm/gas.ex
@@ -153,6 +153,7 @@ defmodule EEVM.Gas do
   def static_cost(0x37), do: @gas_very_low
   # CODESIZE
   def static_cost(0x38), do: @gas_base
+  def static_cost(0x39), do: @gas_very_low
   # GASPRICE
   def static_cost(0x3A), do: @gas_base
   # RETURNDATASIZE

--- a/lib/eevm/opcodes.ex
+++ b/lib/eevm/opcodes.ex
@@ -63,6 +63,7 @@ defmodule EEVM.Opcodes do
   @calldatasize 0x36
   @calldatacopy 0x37
   @codesize 0x38
+  @codecopy 0x39
   @gasprice 0x3A
   @returndatasize 0x3D
   @returndatacopy 0x3E
@@ -162,6 +163,7 @@ defmodule EEVM.Opcodes do
   def info(@calldataload), do: {:ok, %{name: "CALLDATALOAD", inputs: 1, outputs: 1}}
   def info(@calldatasize), do: {:ok, %{name: "CALLDATASIZE", inputs: 0, outputs: 1}}
   def info(@calldatacopy), do: {:ok, %{name: "CALLDATACOPY", inputs: 3, outputs: 0}}
+  def info(@codecopy), do: {:ok, %{name: "CODECOPY", inputs: 3, outputs: 0}}
   def info(@returndatacopy), do: {:ok, %{name: "RETURNDATACOPY", inputs: 3, outputs: 0}}
   def info(@codesize), do: {:ok, %{name: "CODESIZE", inputs: 0, outputs: 1}}
   def info(@gasprice), do: {:ok, %{name: "GASPRICE", inputs: 0, outputs: 1}}

--- a/lib/eevm/opcodes/environment.ex
+++ b/lib/eevm/opcodes/environment.ex
@@ -134,6 +134,41 @@ defmodule EEVM.Opcodes.Environment do
   end
 
   def execute(0x38, state), do: Helpers.push_value(state, byte_size(state.code))
+
+  def execute(0x39, state) do
+    with {:ok, dest_offset, s1} <- Stack.pop(state.stack),
+         {:ok, code_offset, s2} <- Stack.pop(s1),
+         {:ok, length, s3} <- Stack.pop(s2) do
+      if length == 0 do
+        {:ok, %{state | stack: s3} |> MachineState.advance_pc()}
+      else
+        dynamic_cost =
+          Gas.copy_cost(length) +
+            Gas.memory_expansion_cost(Memory.size(state.memory), dest_offset, length)
+
+        case MachineState.consume_gas(%{state | stack: s3}, dynamic_cost) do
+          {:ok, state_after_gas} ->
+            bytes = MachineState.read_code(state_after_gas, code_offset, length)
+
+            new_memory =
+              bytes
+              |> :binary.bin_to_list()
+              |> Enum.with_index()
+              |> Enum.reduce(state_after_gas.memory, fn {byte, i}, mem ->
+                Memory.store_byte(mem, dest_offset + i, byte)
+              end)
+
+            {:ok, %{state_after_gas | memory: new_memory} |> MachineState.advance_pc()}
+
+          {:error, :out_of_gas, halted_state} ->
+            {:error, :out_of_gas, halted_state}
+        end
+      end
+    else
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
   def execute(0x3A, state), do: Helpers.push_value(state, state.tx.gasprice)
   def execute(0x3D, state), do: Helpers.push_value(state, byte_size(state.return_data))
 

--- a/test/opcodes/environment_test.exs
+++ b/test/opcodes/environment_test.exs
@@ -236,6 +236,51 @@ defmodule EEVM.Opcodes.EnvironmentTest do
     end
   end
 
+  describe "CODECOPY (0x39)" do
+    test "copies code bytes to memory" do
+      code = <<0x60, 4, 0x60, 11, 0x60, 0, 0x39, 0x60, 0, 0x51, 0x00, 0xAA, 0xBB, 0xCC, 0xDD>>
+
+      result = EEVM.execute(code)
+
+      expected = 0xAABBCCDD00000000000000000000000000000000000000000000000000000000
+      assert EEVM.stack_values(result) == [expected]
+    end
+
+    test "zero-pads when reading beyond code length" do
+      code = <<0x60, 4, 0x60, 13, 0x60, 0, 0x39, 0x60, 0, 0x51, 0x00, 0xAA, 0xBB, 0xCC, 0xDD>>
+
+      result = EEVM.execute(code)
+
+      expected = :binary.decode_unsigned(<<0xCC, 0xDD, 0x00, 0x00, 0::224>>)
+      assert EEVM.stack_values(result) == [expected]
+    end
+
+    test "zero-length copy is a no-op" do
+      code = <<0x60, 0, 0x60, 200, 0x60, 10, 0x39, 0x59, 0x00>>
+
+      result = EEVM.execute(code)
+
+      assert result.status == :stopped
+      assert EEVM.stack_values(result) == [0]
+    end
+
+    test "gas calculation includes static, copy, and memory expansion" do
+      code = <<0x60, 4, 0x60, 11, 0x60, 0, 0x39, 0x60, 0, 0x51, 0x00, 0xAA, 0xBB, 0xCC, 0xDD>>
+      initial_gas = 1_000
+
+      result = EEVM.execute(code, gas: initial_gas)
+
+      expected_spent =
+        Gas.static_cost(0x60) * 4 +
+          Gas.static_cost(0x39) +
+          Gas.copy_cost(4) +
+          Gas.memory_expansion_cost(0, 0, 4) +
+          Gas.static_cost(0x51)
+
+      assert result.gas == initial_gas - expected_spent
+    end
+  end
+
   describe "RETURNDATACOPY (0x3E)" do
     test "copies return data to memory" do
       return_data = <<0xAA, 0xBB, 0xCC, 0xDD>>


### PR DESCRIPTION
## Summary
- Add CODECOPY (0x39) opcode metadata and gas configuration.
- Implement CODECOPY execution with dynamic copy + memory expansion costs and zero-padding beyond code bounds.
- Add focused opcode tests covering in-bounds copy, out-of-bounds zero-padding, zero-length behavior, and gas accounting.

Closes #10