### PR TITLE
Implement DELEGATECALL and CALLCODE opcodes

### DIFF
--- a/lib/eevm/executor.ex
+++ b/lib/eevm/executor.ex
@@ -168,7 +168,7 @@ defmodule EEVM.Executor do
   defp execute_opcode(op, state) when op in 0x60..0x9F, do: ControlFlow.execute(op, state)
   defp execute_opcode(op, state) when op in 0xA0..0xA4, do: Logging.execute(op, state)
 
-  defp execute_opcode(op, state) when op in [0xF0, 0xF1, 0xF5, 0xFA],
+  defp execute_opcode(op, state) when op in [0xF0, 0xF1, 0xF2, 0xF4, 0xF5, 0xFA],
     do: Creation.execute(op, state)
 
   defp execute_opcode(op, state) when op in [0xF3, 0xFD, 0xFE], do: Termination.execute(op, state)

--- a/lib/eevm/gas/static.ex
+++ b/lib/eevm/gas/static.ex
@@ -100,7 +100,9 @@ defmodule EEVM.Gas.Static do
 
   def static_cost(0xF0), do: @gas_create
   def static_cost(0xF1), do: @gas_warm_access
+  def static_cost(0xF2), do: @gas_warm_access
   def static_cost(0xF3), do: @gas_zero
+  def static_cost(0xF4), do: @gas_warm_access
   def static_cost(0xF5), do: @gas_create
   def static_cost(0xFA), do: @gas_warm_access
   def static_cost(0xFD), do: @gas_zero

--- a/lib/eevm/opcodes/registry.ex
+++ b/lib/eevm/opcodes/registry.ex
@@ -87,7 +87,9 @@ defmodule EEVM.Opcodes.Registry do
 
   @create 0xF0
   @call 0xF1
+  @callcode 0xF2
   @return_ 0xF3
+  @delegatecall 0xF4
   @create2 0xF5
   @staticcall 0xFA
   @revert 0xFD
@@ -167,6 +169,8 @@ defmodule EEVM.Opcodes.Registry do
     @log4 => %{name: "LOG4", inputs: 6, outputs: 0},
     @create => %{name: "CREATE", inputs: 3, outputs: 1},
     @call => %{name: "CALL", inputs: 7, outputs: 1},
+    @callcode => %{name: "CALLCODE", inputs: 7, outputs: 1},
+    @delegatecall => %{name: "DELEGATECALL", inputs: 6, outputs: 1},
     @create2 => %{name: "CREATE2", inputs: 4, outputs: 1},
     @staticcall => %{name: "STATICCALL", inputs: 6, outputs: 1},
     @return_ => %{name: "RETURN", inputs: 2, outputs: 0},

--- a/lib/eevm/opcodes/system/creation.ex
+++ b/lib/eevm/opcodes/system/creation.ex
@@ -62,6 +62,72 @@ defmodule EEVM.Opcodes.System.Creation do
     end
   end
 
+  def execute(0xF2, state) do
+    with {:ok, gas_requested, s1} <- Stack.pop(state.stack),
+         {:ok, address, s2} <- Stack.pop(s1),
+         {:ok, value, s3} <- Stack.pop(s2),
+         {:ok, args_offset, s4} <- Stack.pop(s3),
+         {:ok, args_size, s5} <- Stack.pop(s4),
+         {:ok, ret_offset, s6} <- Stack.pop(s5),
+         {:ok, ret_size, s7} <- Stack.pop(s6) do
+      cond do
+        state.depth >= 1024 ->
+          call_failed(state, s7)
+
+        state.is_static and value > 0 ->
+          call_failed(state, s7)
+
+        true ->
+          execute_delegatecall(
+            state,
+            s7,
+            gas_requested,
+            address,
+            value,
+            args_offset,
+            args_size,
+            ret_offset,
+            ret_size,
+            state.contract.address,
+            true,
+            true
+          )
+      end
+    else
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
+  def execute(0xF4, state) do
+    with {:ok, gas_requested, s1} <- Stack.pop(state.stack),
+         {:ok, address, s2} <- Stack.pop(s1),
+         {:ok, args_offset, s3} <- Stack.pop(s2),
+         {:ok, args_size, s4} <- Stack.pop(s3),
+         {:ok, ret_offset, s5} <- Stack.pop(s4),
+         {:ok, ret_size, s6} <- Stack.pop(s5) do
+      if state.depth >= 1024 do
+        call_failed(state, s6)
+      else
+        execute_delegatecall(
+          state,
+          s6,
+          gas_requested,
+          address,
+          state.contract.callvalue,
+          args_offset,
+          args_size,
+          ret_offset,
+          ret_size,
+          state.contract.caller,
+          false,
+          false
+        )
+      end
+    else
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
   def execute(0xFA, state) do
     with {:ok, gas_requested, s1} <- Stack.pop(state.stack),
          {:ok, address, s2} <- Stack.pop(s1),
@@ -367,6 +433,105 @@ defmodule EEVM.Opcodes.System.Creation do
       {:error, :insufficient_balance} ->
         call_failed(%{state | stack: stack, gas: state.gas - call_cost}, stack)
 
+      {:error, :out_of_gas, halted_state} ->
+        {:error, :out_of_gas, halted_state}
+    end
+  end
+
+  defp execute_delegatecall(
+         state,
+         stack,
+         gas_requested,
+         address,
+         callvalue,
+         args_offset,
+         args_size,
+         ret_offset,
+         ret_size,
+         caller,
+         charge_value_cost?,
+         add_stipend?
+       ) do
+    call_cost =
+      if(charge_value_cost?, do: Dynamic.call_value_cost(callvalue), else: 0) +
+        call_memory_expansion_cost(state.memory, args_offset, args_size, ret_offset, ret_size)
+
+    with {:ok, state_after_cost} <- MachineState.consume_gas(%{state | stack: stack}, call_cost) do
+      {calldata, memory_after_read} =
+        Memory.read_bytes(state_after_cost.memory, args_offset, args_size)
+
+      forwarded_gas = Dynamic.call_forwarded_gas(state_after_cost.gas, gas_requested)
+
+      case MachineState.consume_gas(
+             %{state_after_cost | memory: memory_after_read},
+             forwarded_gas
+           ) do
+        {:ok, state_after_forward} ->
+          target_code = WorldState.get_code(state_after_forward.world_state, address)
+
+          child_contract =
+            Contract.new(
+              address: state_after_forward.contract.address,
+              caller: caller,
+              callvalue: callvalue,
+              calldata: calldata,
+              balances: state_after_forward.contract.balances
+            )
+
+          child_gas =
+            forwarded_gas + if(add_stipend?, do: Dynamic.call_stipend(callvalue), else: 0)
+
+          child_state =
+            MachineState.new(target_code,
+              gas: child_gas,
+              storage: state_after_forward.storage,
+              tx: state_after_forward.tx,
+              block: state_after_forward.block,
+              contract: child_contract,
+              world_state: state_after_forward.world_state,
+              is_static: state_after_forward.is_static,
+              depth: state_after_forward.depth + 1
+            )
+
+          child_result = Executor.run_loop(child_state)
+          call_succeeded = child_result.status == :stopped
+
+          world_state_result =
+            if call_succeeded,
+              do: child_result.world_state,
+              else: state_after_forward.world_state
+
+          storage_result =
+            if call_succeeded,
+              do: child_result.storage,
+              else: state_after_forward.storage
+
+          logs_result =
+            if call_succeeded,
+              do: state_after_forward.logs ++ child_result.logs,
+              else: state_after_forward.logs
+
+          memory_result =
+            write_return_data(memory_after_read, ret_offset, ret_size, child_result.return_data)
+
+          result_flag = if(call_succeeded, do: 1, else: 0)
+          {:ok, stack_after_call} = Stack.push(state_after_forward.stack, result_flag)
+
+          {:ok,
+           state_after_forward
+           |> Map.put(:stack, stack_after_call)
+           |> Map.put(:memory, memory_result)
+           |> Map.put(:return_data, child_result.return_data)
+           |> Map.put(:world_state, world_state_result)
+           |> Map.put(:storage, storage_result)
+           |> Map.put(:logs, logs_result)
+           |> Map.put(:gas, state_after_forward.gas + child_result.gas)
+           |> MachineState.advance_pc()}
+
+        {:error, :out_of_gas, _halted_state} ->
+          call_failed(state_after_cost, stack)
+      end
+    else
       {:error, :out_of_gas, halted_state} ->
         {:error, :out_of_gas, halted_state}
     end

--- a/test/opcodes/system_test.exs
+++ b/test/opcodes/system_test.exs
@@ -3,7 +3,8 @@ defmodule EEVM.Opcodes.SystemTest do
 
   import EEVM.TestSupport.BytecodeHelpers
 
-  alias EEVM.{Memory, WorldState}
+  alias EEVM.{Memory, Storage, WorldState}
+  alias EEVM.Context.Contract
 
   describe "Executor - Return & Halt" do
     test "RETURN returns data from memory" do
@@ -259,6 +260,135 @@ defmodule EEVM.Opcodes.SystemTest do
       assert EEVM.stack_values(result) == [1]
       assert WorldState.get_balance(result.world_state, 0) == 9
       assert WorldState.get_balance(result.world_state, 1) == 0
+    end
+  end
+
+  describe "DELEGATECALL (0xF4)" do
+    test "runs target code in caller's storage context" do
+      child_code = <<0x60, 0x01, 0x30, 0x55, 0x00>>
+
+      world_state =
+        WorldState.new(%{
+          1 => %{code: child_code}
+        })
+
+      code =
+        <<0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x01, 0x61, 0xFF, 0xFF, 0xF4,
+          0x00>>
+
+      contract = Contract.new(address: 0xAA, caller: 0xBEEF, callvalue: 999)
+      result = EEVM.execute(code, world_state: world_state, contract: contract)
+
+      assert EEVM.stack_values(result) == [1]
+      assert Storage.load(result.storage, 0xAA) == 1
+      assert Storage.load(result.storage, 0x01) == 0
+    end
+
+    test "preserves caller (msg.sender)" do
+      child_code = <<0x33, 0x60, 0x00, 0x55, 0x00>>
+      world_state = WorldState.new(%{1 => %{code: child_code}})
+
+      code =
+        <<0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x01, 0x61, 0xFF, 0xFF, 0xF4,
+          0x00>>
+
+      contract = Contract.new(address: 0xAA, caller: 0xBEEF, callvalue: 999)
+      result = EEVM.execute(code, world_state: world_state, contract: contract)
+
+      assert EEVM.stack_values(result) == [1]
+      assert Storage.load(result.storage, 0) == 0xBEEF
+    end
+
+    test "preserves callvalue (msg.value)" do
+      child_code = <<0x34, 0x60, 0x00, 0x55, 0x00>>
+      world_state = WorldState.new(%{1 => %{code: child_code}})
+
+      code =
+        <<0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x01, 0x61, 0xFF, 0xFF, 0xF4,
+          0x00>>
+
+      contract = Contract.new(address: 0xAA, caller: 0xBEEF, callvalue: 999)
+      result = EEVM.execute(code, world_state: world_state, contract: contract)
+
+      assert EEVM.stack_values(result) == [1]
+      assert Storage.load(result.storage, 0) == 999
+    end
+
+    test "ADDRESS returns parent's address" do
+      child_code = <<0x30, 0x60, 0x00, 0x55, 0x00>>
+      world_state = WorldState.new(%{1 => %{code: child_code}})
+
+      code =
+        <<0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x01, 0x61, 0xFF, 0xFF, 0xF4,
+          0x00>>
+
+      contract = Contract.new(address: 0xAA, caller: 0xBEEF, callvalue: 999)
+      result = EEVM.execute(code, world_state: world_state, contract: contract)
+
+      assert EEVM.stack_values(result) == [1]
+      assert Storage.load(result.storage, 0) == 0xAA
+    end
+
+    test "pushes 0 on failure" do
+      child_code = <<0x60, 0x00, 0x60, 0x00, 0xFD>>
+      world_state = WorldState.new(%{1 => %{code: child_code}})
+
+      code =
+        <<0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x01, 0x60, 0x64, 0xF4, 0x00>>
+
+      result = EEVM.execute(code, world_state: world_state)
+
+      assert result.status == :stopped
+      assert EEVM.stack_values(result) == [0]
+      assert result.return_data == <<>>
+    end
+  end
+
+  describe "CALLCODE (0xF2)" do
+    test "runs target code in caller's storage context" do
+      child_code = <<0x60, 0x01, 0x30, 0x55, 0x00>>
+      world_state = WorldState.new(%{1 => %{code: child_code}})
+
+      code =
+        <<0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x01, 0x61, 0xFF,
+          0xFF, 0xF2, 0x00>>
+
+      contract = Contract.new(address: 0xAA, caller: 0xBEEF)
+      result = EEVM.execute(code, world_state: world_state, contract: contract)
+
+      assert EEVM.stack_values(result) == [1]
+      assert Storage.load(result.storage, 0xAA) == 1
+      assert Storage.load(result.storage, 0x01) == 0
+    end
+
+    test "CALLER returns current contract address" do
+      child_code = <<0x33, 0x60, 0x00, 0x55, 0x00>>
+      world_state = WorldState.new(%{1 => %{code: child_code}})
+
+      code =
+        <<0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x01, 0x61, 0xFF,
+          0xFF, 0xF2, 0x00>>
+
+      contract = Contract.new(address: 0xAAAA, caller: 0xBBBB)
+      result = EEVM.execute(code, world_state: world_state, contract: contract)
+
+      assert EEVM.stack_values(result) == [1]
+      assert Storage.load(result.storage, 0) == 0xAAAA
+    end
+
+    test "pushes 0 on failure" do
+      child_code = <<0x60, 0x00, 0x60, 0x00, 0xFD>>
+      world_state = WorldState.new(%{1 => %{code: child_code}})
+
+      code =
+        <<0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x01, 0x60, 0x64,
+          0xF2, 0x00>>
+
+      result = EEVM.execute(code, world_state: world_state)
+
+      assert result.status == :stopped
+      assert EEVM.stack_values(result) == [0]
+      assert result.return_data == <<>>
     end
   end
 end


### PR DESCRIPTION
## Summary

- Implement `DELEGATECALL` (0xF4) and `CALLCODE` (0xF2) — opcodes that execute another contract's code in the context of the caller
- `DELEGATECALL` preserves the caller's address, `msg.sender`, `msg.value`, and storage context while only loading code from the target address
- `CALLCODE` is the legacy variant where `msg.sender` is set to the current contract's address rather than the original caller

## Changes

- **`lib/eevm/opcodes/registry.ex`** — Add opcode definitions for `CALLCODE` (0xF2, 7 inputs) and `DELEGATECALL` (0xF4, 6 inputs)
- **`lib/eevm/gas/static.ex`** — Add `@gas_warm_access` (100) static cost for both opcodes
- **`lib/eevm/executor.ex`** — Add 0xF2 and 0xF4 to the creation dispatch table
- **`lib/eevm/opcodes/system/creation.ex`** — Implement both opcodes with a new `execute_delegatecall` helper that handles the shared context-delegation logic (separate from `execute_call` to keep CALL untouched)
- **`test/opcodes/system_test.exs`** — Add 8 tests covering:
  - Storage writes happen in caller's context (both opcodes)
  - `CALLER` preserved from parent in DELEGATECALL
  - `CALLVALUE` preserved from parent in DELEGATECALL
  - `ADDRESS` returns parent's address in DELEGATECALL
  - `CALLER` returns current contract address in CALLCODE (key difference)
  - Failure cases push 0

## Test Results

```
173 tests, 0 failures
```

Closes #17