### PR TITLE
Implement STATICCALL opcode

### DIFF
--- a/lib/eevm/executor.ex
+++ b/lib/eevm/executor.ex
@@ -129,6 +129,15 @@ defmodule EEVM.Executor do
   # range to ensure it is caught by its dedicated StackMemoryStorage clause.
   # The fallback clause treats unknown opcodes as INVALID (halt, no gas refund).
 
+  defp execute_opcode(0x55, %{is_static: true} = state),
+    do: {:ok, MachineState.halt(state, :reverted)}
+
+  defp execute_opcode(op, %{is_static: true} = state) when op in 0xA0..0xA4,
+    do: {:ok, MachineState.halt(state, :reverted)}
+
+  defp execute_opcode(op, %{is_static: true} = state) when op in [0xF0, 0xF5],
+    do: {:ok, MachineState.halt(state, :reverted)}
+
   defp execute_opcode(0x00, state), do: Termination.execute(0x00, state)
   defp execute_opcode(op, state) when op in 0x01..0x0B, do: Arithmetic.execute(op, state)
   defp execute_opcode(op, state) when op in 0x10..0x15, do: Comparison.execute(op, state)
@@ -158,7 +167,10 @@ defmodule EEVM.Executor do
   defp execute_opcode(0x5F, state), do: ControlFlow.execute(0x5F, state)
   defp execute_opcode(op, state) when op in 0x60..0x9F, do: ControlFlow.execute(op, state)
   defp execute_opcode(op, state) when op in 0xA0..0xA4, do: Logging.execute(op, state)
-  defp execute_opcode(op, state) when op in [0xF0, 0xF1, 0xF5], do: Creation.execute(op, state)
+
+  defp execute_opcode(op, state) when op in [0xF0, 0xF1, 0xF5, 0xFA],
+    do: Creation.execute(op, state)
+
   defp execute_opcode(op, state) when op in [0xF3, 0xFD, 0xFE], do: Termination.execute(op, state)
   defp execute_opcode(_op, state), do: {:ok, MachineState.halt(state, :invalid)}
 end

--- a/lib/eevm/gas/static.ex
+++ b/lib/eevm/gas/static.ex
@@ -102,6 +102,7 @@ defmodule EEVM.Gas.Static do
   def static_cost(0xF1), do: @gas_warm_access
   def static_cost(0xF3), do: @gas_zero
   def static_cost(0xF5), do: @gas_create
+  def static_cost(0xFA), do: @gas_warm_access
   def static_cost(0xFD), do: @gas_zero
   def static_cost(0xFE), do: @gas_zero
 

--- a/lib/eevm/opcodes/registry.ex
+++ b/lib/eevm/opcodes/registry.ex
@@ -89,6 +89,7 @@ defmodule EEVM.Opcodes.Registry do
   @call 0xF1
   @return_ 0xF3
   @create2 0xF5
+  @staticcall 0xFA
   @revert 0xFD
   @invalid 0xFE
 
@@ -167,6 +168,7 @@ defmodule EEVM.Opcodes.Registry do
     @create => %{name: "CREATE", inputs: 3, outputs: 1},
     @call => %{name: "CALL", inputs: 7, outputs: 1},
     @create2 => %{name: "CREATE2", inputs: 4, outputs: 1},
+    @staticcall => %{name: "STATICCALL", inputs: 6, outputs: 1},
     @return_ => %{name: "RETURN", inputs: 2, outputs: 0},
     @revert => %{name: "REVERT", inputs: 2, outputs: 0},
     @invalid => %{name: "INVALID", inputs: 0, outputs: 0}

--- a/lib/eevm/opcodes/system/creation.ex
+++ b/lib/eevm/opcodes/system/creation.ex
@@ -62,6 +62,33 @@ defmodule EEVM.Opcodes.System.Creation do
     end
   end
 
+  def execute(0xFA, state) do
+    with {:ok, gas_requested, s1} <- Stack.pop(state.stack),
+         {:ok, address, s2} <- Stack.pop(s1),
+         {:ok, args_offset, s3} <- Stack.pop(s2),
+         {:ok, args_size, s4} <- Stack.pop(s3),
+         {:ok, ret_offset, s5} <- Stack.pop(s4),
+         {:ok, ret_size, s6} <- Stack.pop(s5) do
+      if state.depth >= 1024 do
+        call_failed(state, s6)
+      else
+        execute_call(
+          %{state | is_static: true},
+          s6,
+          gas_requested,
+          address,
+          0,
+          args_offset,
+          args_size,
+          ret_offset,
+          ret_size
+        )
+      end
+    else
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
   def execute(_opcode, state), do: {:ok, MachineState.halt(state, :invalid)}
 
   defp execute_create(state, stack, value, offset, size, salt) do

--- a/test/opcodes/system_test.exs
+++ b/test/opcodes/system_test.exs
@@ -159,4 +159,106 @@ defmodule EEVM.Opcodes.SystemTest do
       assert result.return_data == <<>>
     end
   end
+
+  describe "STATICCALL (0xFA)" do
+    test "calls external code in static mode and pushes success flag" do
+      child_code = <<0x60, 0x2A, 0x60, 0x00, 0x53, 0x60, 0x01, 0x60, 0x00, 0xF3>>
+
+      world_state =
+        WorldState.new(%{
+          0 => %{balance: 10},
+          1 => %{balance: 0, code: child_code}
+        })
+
+      code =
+        <<0x60, 0x01, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x01, 0x60, 0x64, 0xFA, 0x00>>
+
+      result = EEVM.execute(code, world_state: world_state)
+
+      assert result.status == :stopped
+      assert EEVM.stack_values(result) == [1]
+      assert result.return_data == <<0x2A>>
+      {mem, _} = Memory.read_bytes(result.memory, 0, 1)
+      assert mem == <<0x2A>>
+    end
+
+    test "pushes failure flag when child attempts SSTORE in static context" do
+      child_code = <<0x60, 0x01, 0x60, 0x00, 0x55, 0x00>>
+
+      world_state =
+        WorldState.new(%{
+          0 => %{balance: 10},
+          1 => %{balance: 0, code: child_code}
+        })
+
+      code =
+        <<0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x01, 0x60, 0x64, 0xFA, 0x00>>
+
+      result = EEVM.execute(code, world_state: world_state)
+
+      assert result.status == :stopped
+      assert EEVM.stack_values(result) == [0]
+      assert EEVM.Storage.load(result.storage, 0) == 0
+    end
+
+    test "pushes failure flag when child attempts LOG in static context" do
+      child_code = <<0x60, 0x00, 0x60, 0x00, 0xA0, 0x00>>
+
+      world_state =
+        WorldState.new(%{
+          0 => %{balance: 10},
+          1 => %{balance: 0, code: child_code}
+        })
+
+      code =
+        <<0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x01, 0x60, 0x64, 0xFA, 0x00>>
+
+      result = EEVM.execute(code, world_state: world_state)
+
+      assert result.status == :stopped
+      assert EEVM.stack_values(result) == [0]
+    end
+
+    test "propagates static mode to nested calls" do
+      grandchild_code = <<0x60, 0x01, 0x60, 0x00, 0x55, 0x00>>
+
+      child_code =
+        <<0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x02, 0x61, 0x75,
+          0x30, 0xF1, 0x60, 0x00, 0x53, 0x60, 0x01, 0x60, 0x00, 0xF3>>
+
+      world_state =
+        WorldState.new(%{
+          0 => %{balance: 10},
+          1 => %{balance: 0, code: child_code},
+          2 => %{balance: 0, code: grandchild_code}
+        })
+
+      code =
+        <<0x60, 0x01, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x01, 0x61, 0xC3, 0x50, 0xFA,
+          0x00>>
+
+      result = EEVM.execute(code, world_state: world_state)
+
+      assert result.status == :stopped
+      assert EEVM.stack_values(result) == [1]
+      assert result.return_data == <<0x00>>
+      {mem, _} = Memory.read_bytes(result.memory, 0, 1)
+      assert mem == <<0x00>>
+      assert EEVM.Storage.load(result.storage, 0) == 0
+    end
+
+    test "does not transfer value" do
+      world_state = WorldState.new(%{0 => %{balance: 9}, 1 => %{balance: 0, code: <<0x00>>}})
+
+      code =
+        <<0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x01, 0x60, 0x64, 0xFA, 0x00>>
+
+      result = EEVM.execute(code, world_state: world_state)
+
+      assert result.status == :stopped
+      assert EEVM.stack_values(result) == [1]
+      assert WorldState.get_balance(result.world_state, 0) == 9
+      assert WorldState.get_balance(result.world_state, 1) == 0
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Implement `STATICCALL` (0xFA) — a read-only variant of `CALL` that reverts on any state modification
- Add static mode enforcement that blocks `SSTORE`, `CREATE`, `CREATE2`, and `LOG0-LOG4` in static contexts
- The static flag propagates through the entire call chain (nested calls inherit static mode)

## Changes

- **`lib/eevm/opcodes/registry.ex`** — Add opcode definition for `STATICCALL` (0xFA, 6 inputs)
- **`lib/eevm/gas/static.ex`** — Add `@gas_warm_access` (100) static cost
- **`lib/eevm/executor.ex`** — Add 0xFA to the creation dispatch table and add static mode enforcement via pattern-matched dispatch clauses before normal dispatch:
  - `SSTORE` (0x55) in static → revert
  - `LOG0-LOG4` (0xA0-0xA4) in static → revert
  - `CREATE`/`CREATE2` (0xF0/0xF5) in static → revert
- **`lib/eevm/opcodes/system/creation.ex`** — Implement `STATICCALL` reusing `execute_call` with `value=0` and `is_static=true`
- **`test/opcodes/system_test.exs`** — Add 5 tests covering:
  - Successful read-only call returns data
  - `SSTORE` in static context causes revert
  - `LOG0` in static context causes revert
  - Static flag propagates through nested calls
  - No value transfer (balances unchanged)

## Test Results

```
170 tests, 0 failures
```

Closes #16