### PR TITLE
Implement BLOBHASH and BLOBBASEFEE opcodes (EIP-4844/EIP-7516)

### DIFF
--- a/lib/eevm/context/block.ex
+++ b/lib/eevm/context/block.ex
@@ -19,6 +19,7 @@ defmodule EEVM.Context.Block do
   | `gaslimit` | GASLIMIT (0x45) | Block gas limit |
   | `prevrandao` | PREVRANDAO (0x44) | Previous block's RANDAO mix (post-Merge) |
   | `basefee` | BASEFEE (0x48) | Block base fee from EIP-1559 |
+  | `blob_base_fee` | BLOBBASEFEE (0x4A) | Block blob base fee from EIP-7516 |
   | `chain_id` | CHAINID (0x46) | Network ID (1=mainnet, 137=Polygon, etc.) |
   | `hashes` | BLOCKHASH (0x40) | Map of recent block numbers to their hashes |
 
@@ -42,6 +43,7 @@ defmodule EEVM.Context.Block do
           gaslimit: non_neg_integer(),
           prevrandao: non_neg_integer(),
           basefee: non_neg_integer(),
+          blob_base_fee: non_neg_integer(),
           chain_id: non_neg_integer(),
           hashes: %{non_neg_integer() => non_neg_integer()}
         }
@@ -52,6 +54,7 @@ defmodule EEVM.Context.Block do
             gaslimit: 0,
             prevrandao: 0,
             basefee: 0,
+            blob_base_fee: 0,
             chain_id: 1,
             hashes: %{}
 

--- a/lib/eevm/context/transaction.ex
+++ b/lib/eevm/context/transaction.ex
@@ -16,6 +16,7 @@ defmodule EEVM.Context.Transaction do
   |-------|--------|-------------|
   | `origin` | ORIGIN (0x32) | The externally owned account (EOA) that signed the tx |
   | `gasprice` | GASPRICE (0x3A) | Gas price in wei the sender is paying |
+  | `blob_hashes` | BLOBHASH (0x49) | List of blob versioned hashes from EIP-4844 transaction payload |
 
   ### Origin vs Caller
 
@@ -32,11 +33,13 @@ defmodule EEVM.Context.Transaction do
 
   @type t :: %__MODULE__{
           origin: non_neg_integer(),
-          gasprice: non_neg_integer()
+          gasprice: non_neg_integer(),
+          blob_hashes: [non_neg_integer()]
         }
 
   defstruct origin: 0,
-            gasprice: 0
+            gasprice: 0,
+            blob_hashes: []
 
   @doc "Creates a new transaction context with default values."
   @spec new() :: t()

--- a/lib/eevm/executor.ex
+++ b/lib/eevm/executor.ex
@@ -155,8 +155,9 @@ defmodule EEVM.Executor do
   defp execute_opcode(op, state) when op in [0x31, 0x3B, 0x3C, 0x3F],
     do: External.execute(op, state)
 
-  defp execute_opcode(op, state) when op in [0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x48],
-    do: Simple.execute(op, state)
+  defp execute_opcode(op, state)
+       when op in [0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x48, 0x49, 0x4A],
+       do: Simple.execute(op, state)
 
   defp execute_opcode(0x47, state), do: External.execute(0x47, state)
   defp execute_opcode(0x50, state), do: StackOps.execute(0x50, state)

--- a/lib/eevm/gas/static.ex
+++ b/lib/eevm/gas/static.ex
@@ -76,6 +76,8 @@ defmodule EEVM.Gas.Static do
   def static_cost(0x46), do: @gas_base
   def static_cost(0x47), do: @gas_selfbalance
   def static_cost(0x48), do: @gas_base
+  def static_cost(0x49), do: @gas_very_low
+  def static_cost(0x4A), do: @gas_base
 
   def static_cost(0x50), do: @gas_base
   def static_cost(0x51), do: @gas_very_low

--- a/lib/eevm/opcodes/environment/simple.ex
+++ b/lib/eevm/opcodes/environment/simple.ex
@@ -22,6 +22,7 @@ defmodule EEVM.Opcodes.Environment.Simple do
   def execute(0x45, state), do: Helpers.push_value(state, state.block.gaslimit)
   def execute(0x46, state), do: Helpers.push_value(state, state.block.chain_id)
   def execute(0x48, state), do: Helpers.push_value(state, state.block.basefee)
+  def execute(0x4A, state), do: Helpers.push_value(state, state.block.blob_base_fee)
   def execute(0x5A, state), do: Helpers.push_value(state, state.gas)
 
   def execute(0x40, state) do
@@ -29,6 +30,19 @@ defmodule EEVM.Opcodes.Environment.Simple do
          hash = Block.hash(state.block, block_num),
          {:ok, s2} <- Stack.push(s1, hash) do
       {:ok, %{state | stack: s2} |> MachineState.advance_pc()}
+    else
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
+  def execute(0x49, state) do
+    with {:ok, index, s1} <- Stack.pop(state.stack) do
+      value = Enum.at(state.tx.blob_hashes, index, 0)
+
+      case Stack.push(s1, value) do
+        {:ok, s2} -> {:ok, %{state | stack: s2} |> MachineState.advance_pc()}
+        {:error, reason} -> {:error, reason, state}
+      end
     else
       {:error, reason} -> {:error, reason, state}
     end

--- a/test/opcodes/blob_test.exs
+++ b/test/opcodes/blob_test.exs
@@ -1,0 +1,64 @@
+defmodule EEVM.Opcodes.BlobTest do
+  use ExUnit.Case, async: true
+
+  alias EEVM.Context.{Transaction, Block}
+  alias EEVM.Gas.Static
+
+  describe "BLOBHASH (0x49) - EIP-4844" do
+    test "returns versioned hash at valid index" do
+      tx = Transaction.new(blob_hashes: [0xAABB, 0xCCDD, 0xEEFF])
+      code = <<0x60, 0x00, 0x49, 0x00>>
+      result = EEVM.execute(code, tx: tx)
+      assert EEVM.stack_values(result) == [0xAABB]
+    end
+
+    test "returns hash at index 1" do
+      tx = Transaction.new(blob_hashes: [0xAABB, 0xCCDD, 0xEEFF])
+      code = <<0x60, 0x01, 0x49, 0x00>>
+      result = EEVM.execute(code, tx: tx)
+      assert EEVM.stack_values(result) == [0xCCDD]
+    end
+
+    test "returns 0 for out-of-range index" do
+      tx = Transaction.new(blob_hashes: [0xAABB])
+      code = <<0x60, 0x05, 0x49, 0x00>>
+      result = EEVM.execute(code, tx: tx)
+      assert EEVM.stack_values(result) == [0]
+    end
+
+    test "returns 0 with empty blob list" do
+      code = <<0x60, 0x00, 0x49, 0x00>>
+      result = EEVM.execute(code)
+      assert EEVM.stack_values(result) == [0]
+    end
+
+    test "costs 3 gas (very low)" do
+      code = <<0x60, 0x00, 0x49, 0x00>>
+      result = EEVM.execute(code, gas: 10_000)
+      expected_cost = Static.static_cost(0x60) + Static.static_cost(0x49)
+      assert result.gas == 10_000 - expected_cost
+    end
+  end
+
+  describe "BLOBBASEFEE (0x4A) - EIP-7516" do
+    test "returns block blob base fee" do
+      block = Block.new(blob_base_fee: 1_000_000)
+      code = <<0x4A, 0x00>>
+      result = EEVM.execute(code, block: block)
+      assert EEVM.stack_values(result) == [1_000_000]
+    end
+
+    test "returns 0 by default" do
+      code = <<0x4A, 0x00>>
+      result = EEVM.execute(code)
+      assert EEVM.stack_values(result) == [0]
+    end
+
+    test "costs 2 gas (base)" do
+      code = <<0x4A, 0x00>>
+      result = EEVM.execute(code, gas: 10_000)
+      expected_cost = Static.static_cost(0x4A)
+      assert result.gas == 10_000 - expected_cost
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implements BLOBHASH (0x49) per [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) and BLOBBASEFEE (0x4A) per [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516)
- BLOBHASH pops an index from the stack and pushes the versioned hash at that index (or 0 if out of range)
- BLOBBASEFEE pushes the current block's blob base fee

## Changes
- **`context/transaction.ex`** — Added `blob_hashes: []` field (list of versioned hashes)
- **`context/block.ex`** — Added `blob_base_fee: 0` field
- **`environment/simple.ex`** — BLOBHASH handler with stack pop + list lookup; BLOBBASEFEE as simple value push
- **`gas/static.ex`** — BLOBHASH costs 3 gas (`@gas_very_low`), BLOBBASEFEE costs 2 gas (`@gas_base`)
- **`executor.ex`** — Added 0x49, 0x4A to environment simple dispatch (no static rejection needed — read-only)
- **`blob_test.exs`** — 8 tests covering valid index, index 1, out-of-range, empty list, default value, and gas costs

## Verification
- `mix compile --warnings-as-errors` ✅
- `mix test` — 186 tests, 0 failures ✅

Closes #33