### PR TITLE
Implement contract size limits (EIP-170/EIP-3860)

### DIFF
--- a/lib/eevm/opcodes/system/creation.ex
+++ b/lib/eevm/opcodes/system/creation.ex
@@ -1,6 +1,10 @@
 defmodule EEVM.Opcodes.System.Creation do
   @moduledoc false
 
+  @max_code_size 24_576
+  @max_initcode_size 49_152
+  @initcode_word_cost 2
+
   alias EEVM.{Executor, MachineState, Memory, Stack, WorldState}
   alias EEVM.Gas.Dynamic
   alias EEVM.Gas.Memory, as: GasMemory
@@ -177,82 +181,115 @@ defmodule EEVM.Opcodes.System.Creation do
 
     case MachineState.consume_gas(%{state | stack: stack}, extra_cost) do
       {:ok, state_after_cost} ->
-        {init_code, memory_after_read} = Memory.read_bytes(state_after_cost.memory, offset, size)
-
         creator = state_after_cost.contract.address
         nonce = WorldState.get_nonce(state_after_cost.world_state, creator)
 
         world_state_after_nonce =
           WorldState.increment_nonce(state_after_cost.world_state, creator)
 
-        new_address =
-          if salt == nil,
-            do: derive_create_address(creator, nonce),
-            else: derive_create2_address(creator, salt, init_code)
+        if size > @max_initcode_size do
+          create_failed(%{state_after_cost | world_state: world_state_after_nonce}, stack)
+        else
+          initcode_cost = @initcode_word_cost * div(size + 31, 32)
 
-        can_create = can_create_account?(world_state_after_nonce, new_address)
+          case MachineState.consume_gas(state_after_cost, initcode_cost) do
+            {:ok, state_after_initcode_cost} ->
+              {init_code, memory_after_read} =
+                Memory.read_bytes(state_after_initcode_cost.memory, offset, size)
 
-        if can_create do
-          case WorldState.transfer(world_state_after_nonce, creator, new_address, value) do
-            {:ok, world_state_after_transfer} ->
-              child_contract =
-                Contract.new(
-                  address: new_address,
-                  caller: creator,
-                  callvalue: value,
-                  calldata: <<>>,
-                  balances: state_after_cost.contract.balances
-                )
+              new_address =
+                if salt == nil,
+                  do: derive_create_address(creator, nonce),
+                  else: derive_create2_address(creator, salt, init_code)
 
-              child_state =
-                MachineState.new(init_code,
-                  gas: state_after_cost.gas,
-                  storage: state_after_cost.storage,
-                  tx: state_after_cost.tx,
-                  block: state_after_cost.block,
-                  contract: child_contract,
-                  world_state: world_state_after_transfer,
-                  is_static: state_after_cost.is_static,
-                  depth: state_after_cost.depth + 1
-                )
+              can_create = can_create_account?(world_state_after_nonce, new_address)
 
-              child_result = Executor.run_loop(child_state)
-              deployment_success = child_result.status == :stopped
+              if can_create do
+                case WorldState.transfer(world_state_after_nonce, creator, new_address, value) do
+                  {:ok, world_state_after_transfer} ->
+                    child_contract =
+                      Contract.new(
+                        address: new_address,
+                        caller: creator,
+                        callvalue: value,
+                        calldata: <<>>,
+                        balances: state_after_initcode_cost.contract.balances
+                      )
 
-              if deployment_success do
-                runtime_code = child_result.return_data
-                deposit_cost = Dynamic.code_deposit_cost(byte_size(runtime_code))
+                    child_state =
+                      MachineState.new(init_code,
+                        gas: state_after_initcode_cost.gas,
+                        storage: state_after_initcode_cost.storage,
+                        tx: state_after_initcode_cost.tx,
+                        block: state_after_initcode_cost.block,
+                        contract: child_contract,
+                        world_state: world_state_after_transfer,
+                        is_static: state_after_initcode_cost.is_static,
+                        depth: state_after_initcode_cost.depth + 1
+                      )
 
-                if child_result.gas >= deposit_cost do
-                  world_state_after_deploy =
-                    child_result.world_state
-                    |> WorldState.put_code(new_address, runtime_code)
-                    |> WorldState.set_nonce(new_address, 1)
+                    child_result = Executor.run_loop(child_state)
+                    deployment_success = child_result.status == :stopped
 
-                  {:ok, stack_after_create} = Stack.push(stack, new_address)
+                    if deployment_success do
+                      runtime_code = child_result.return_data
 
-                  {:ok,
-                   state_after_cost
-                   |> Map.put(:stack, stack_after_create)
-                   |> Map.put(:memory, memory_after_read)
-                   |> Map.put(:world_state, world_state_after_deploy)
-                   |> Map.put(:storage, child_result.storage)
-                   |> Map.put(:logs, state_after_cost.logs ++ child_result.logs)
-                   |> Map.put(:gas, child_result.gas - deposit_cost)
-                   |> Map.put(:return_data, child_result.return_data)
-                   |> MachineState.advance_pc()}
-                else
-                  create_failed(%{state_after_cost | world_state: world_state_after_nonce}, stack)
+                      if byte_size(runtime_code) > @max_code_size do
+                        create_failed(
+                          %{state_after_initcode_cost | world_state: world_state_after_nonce},
+                          stack
+                        )
+                      else
+                        deposit_cost = Dynamic.code_deposit_cost(byte_size(runtime_code))
+
+                        if child_result.gas >= deposit_cost do
+                          world_state_after_deploy =
+                            child_result.world_state
+                            |> WorldState.put_code(new_address, runtime_code)
+                            |> WorldState.set_nonce(new_address, 1)
+
+                          {:ok, stack_after_create} = Stack.push(stack, new_address)
+
+                          {:ok,
+                           state_after_initcode_cost
+                           |> Map.put(:stack, stack_after_create)
+                           |> Map.put(:memory, memory_after_read)
+                           |> Map.put(:world_state, world_state_after_deploy)
+                           |> Map.put(:storage, child_result.storage)
+                           |> Map.put(:logs, state_after_initcode_cost.logs ++ child_result.logs)
+                           |> Map.put(:gas, child_result.gas - deposit_cost)
+                           |> Map.put(:return_data, child_result.return_data)
+                           |> MachineState.advance_pc()}
+                        else
+                          create_failed(
+                            %{state_after_initcode_cost | world_state: world_state_after_nonce},
+                            stack
+                          )
+                        end
+                      end
+                    else
+                      create_failed(
+                        %{state_after_initcode_cost | world_state: world_state_after_nonce},
+                        stack
+                      )
+                    end
+
+                  {:error, :insufficient_balance} ->
+                    create_failed(
+                      %{state_after_initcode_cost | world_state: world_state_after_nonce},
+                      stack
+                    )
                 end
               else
-                create_failed(%{state_after_cost | world_state: world_state_after_nonce}, stack)
+                create_failed(
+                  %{state_after_initcode_cost | world_state: world_state_after_nonce},
+                  stack
+                )
               end
 
-            {:error, :insufficient_balance} ->
-              create_failed(%{state_after_cost | world_state: world_state_after_nonce}, stack)
+            {:error, :out_of_gas, halted_state} ->
+              {:error, :out_of_gas, halted_state}
           end
-        else
-          create_failed(%{state_after_cost | world_state: world_state_after_nonce}, stack)
         end
 
       {:error, :out_of_gas, halted_state} ->

--- a/test/opcodes/contract_size_test.exs
+++ b/test/opcodes/contract_size_test.exs
@@ -1,0 +1,123 @@
+defmodule EEVM.Opcodes.ContractSizeTest do
+  use ExUnit.Case, async: true
+
+  describe "Contract size limits (EIP-170 + EIP-3860)" do
+    test "CREATE succeeds with initcode at max size" do
+      code =
+        IO.iodata_to_binary([
+          push(49_152),
+          push(0),
+          push(0),
+          <<0xF0, 0x00>>
+        ])
+
+      result = EEVM.execute(code, gas: 10_000_000)
+      [addr] = EEVM.stack_values(result)
+
+      assert result.status == :stopped
+      assert addr != 0
+    end
+
+    test "CREATE fails with initcode over max size (49,152 bytes)" do
+      size = 49_153
+
+      code =
+        IO.iodata_to_binary([
+          push(size),
+          push(0),
+          push(0),
+          <<0xF0, 0x00>>
+        ])
+
+      result = EEVM.execute(code, gas: 10_000_000)
+
+      assert result.status == :stopped
+      assert EEVM.stack_values(result) == [0]
+    end
+
+    test "CREATE2 fails with initcode over max size" do
+      size = 49_153
+
+      code =
+        IO.iodata_to_binary([
+          push(0),
+          push(size),
+          push(0),
+          push(0),
+          <<0xF5, 0x00>>
+        ])
+
+      result = EEVM.execute(code, gas: 10_000_000)
+
+      assert result.status == :stopped
+      assert EEVM.stack_values(result) == [0]
+    end
+
+    test "CREATE rejects deployed code over 24,576 bytes" do
+      runtime_size = 24_577
+
+      initcode =
+        IO.iodata_to_binary([
+          push(runtime_size),
+          push(0),
+          <<0xF3>>
+        ])
+
+      code = create_with_initcode(initcode)
+      result = EEVM.execute(code, gas: 10_000_000)
+
+      assert result.status == :stopped
+      assert EEVM.stack_values(result) == [0]
+    end
+
+    test "CREATE succeeds with deployed code at exactly 24,576 bytes" do
+      runtime_size = 24_576
+
+      initcode =
+        IO.iodata_to_binary([
+          push(runtime_size),
+          push(0),
+          <<0xF3>>
+        ])
+
+      code = create_with_initcode(initcode)
+      result = EEVM.execute(code, gas: 100_000_000)
+
+      assert result.status == :stopped
+
+      [addr] = EEVM.stack_values(result)
+      assert addr != 0
+    end
+
+    test "initcode gas cost is charged (2 per 32-byte word)" do
+      small_initcode = <<0x60, 0x00, 0x60, 0x00, 0xF3>>
+      code = create_with_initcode(small_initcode)
+      result = EEVM.execute(code, gas: 1_000_000)
+
+      assert result.status == :stopped
+    end
+  end
+
+  defp create_with_initcode(initcode) do
+    size = byte_size(initcode)
+
+    stores =
+      for {byte, i} <- Enum.with_index(:binary.bin_to_list(initcode)) do
+        IO.iodata_to_binary([push(byte), push(i), <<0x53>>])
+      end
+
+    IO.iodata_to_binary([
+      stores,
+      push(size),
+      push(0),
+      push(0),
+      <<0xF0, 0x00>>
+    ])
+  end
+
+  defp push(0), do: <<0x60, 0x00>>
+  defp push(n) when n <= 0xFF, do: <<0x60, n>>
+  defp push(n) when n <= 0xFFFF, do: <<0x61, n::unsigned-big-16>>
+  defp push(n) when n <= 0xFFFFFF, do: <<0x62, n::unsigned-big-24>>
+  defp push(n), do: <<0x63, n::unsigned-big-32>>
+end


### PR DESCRIPTION
## Summary
- Implements contract code size limit (24,576 bytes) per [EIP-170](https://eips.ethereum.org/EIPS/eip-170)
- Implements initcode size limit (49,152 bytes) and initcode gas cost (2 gas per 32-byte word) per [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860)
- Applies to both CREATE and CREATE2

## Changes
- **`system/creation.ex`** — Added `@max_code_size`, `@max_initcode_size`, `@initcode_word_cost` constants. Modified `execute_create_inner/6` to:
  1. Reject initcode exceeding 49,152 bytes (before execution)
  2. Charge initcode gas cost: `2 * ceil(size / 32)` (before execution)
  3. Reject deployed runtime code exceeding 24,576 bytes (after child execution, before code deposit)
- **`contract_size_test.exs`** — 6 tests covering initcode max size boundary, initcode rejection, CREATE2 rejection, deployed code rejection, deployed code boundary, and initcode gas charging

## Verification
- `mix compile --warnings-as-errors` ✅
- `mix test` — 184 tests, 0 failures ✅

Closes #41