### PR TITLE
feat(precompiles): add SHA-256 precompile (address 0x02)

### DIFF
--- a/lib/eevm/precompiles.ex
+++ b/lib/eevm/precompiles.ex
@@ -3,6 +3,7 @@ defmodule EEVM.Precompiles do
 
   alias EEVM.Precompiles.Identity
   alias EEVM.Precompiles.RIPEMD160
+  alias EEVM.Precompiles.SHA256
 
   @spec is_precompile?(non_neg_integer()) :: boolean()
   def is_precompile?(address) when address >= 0x01 and address <= 0x0A, do: true
@@ -10,6 +11,7 @@ defmodule EEVM.Precompiles do
 
   @spec execute(non_neg_integer(), binary(), non_neg_integer()) ::
           {:ok, binary(), non_neg_integer()} | {:error, atom()}
+  def execute(0x02, input, gas_limit), do: SHA256.execute(input, gas_limit)
   def execute(0x03, input, gas_limit), do: RIPEMD160.execute(input, gas_limit)
   def execute(0x04, input, gas_limit), do: Identity.execute(input, gas_limit)
 

--- a/lib/eevm/precompiles/sha256.ex
+++ b/lib/eevm/precompiles/sha256.ex
@@ -1,0 +1,73 @@
+defmodule EEVM.Precompiles.SHA256 do
+  @moduledoc """
+  SHA-256 precompile — address `0x02`.
+
+  ## EVM Concepts
+
+  SHA-256 is the second built-in contract and the only precompile that uses a
+  different hash function than the EVM's native Keccak-256. It is included
+  primarily for **Bitcoin interoperability**: Bitcoin addresses and block headers
+  are SHA-256 based, so on-chain verification of Bitcoin proofs requires access
+  to the function.
+
+  SHA-256 also appears in:
+
+  - **EIP-197 (BN256)** pairing checks, whose inputs are sometimes hashed with
+    SHA-256 before being passed on-chain.
+  - **Beacon chain / consensus layer** — the Ethereum consensus layer uses
+    SHA-256 (not Keccak) for its Merkle tree.
+
+  ### Gas schedule (Yellow Paper §E.2)
+
+  | Component | Cost |
+  |-----------|------|
+  | Base      | 60   |
+  | Per word  | 12 (one word = 32 bytes, rounded up) |
+
+  ### Output format
+
+  Always 32 bytes — the raw SHA-256 digest.
+
+  ## Elixir Learning Notes
+
+  - `:crypto.hash(:sha256, data)` calls into Erlang's OpenSSL-backed `:crypto`
+    NIF (native implemented function). It is significantly faster than a pure
+    Elixir implementation and requires no extra dependencies.
+  - The atom `:sha256` maps to OpenSSL's `EVP_sha256` digest under the hood;
+    Erlang exposes the full OpenSSL digest catalogue this way.
+  """
+
+  @base_cost 60
+  @word_cost 12
+
+  @doc """
+  Executes the SHA-256 precompile.
+
+  Hashes `input` with SHA-256 and returns the 32-byte digest, charging
+  `60 + 12 * ceil(byte_size(input) / 32)` gas.
+
+  ## Examples
+
+      iex> {:ok, digest, _gas} = EEVM.Precompiles.SHA256.execute(<<>>, 1_000)
+      iex> byte_size(digest)
+      32
+
+      iex> EEVM.Precompiles.SHA256.execute(<<1::256>>, 5)
+      {:error, :out_of_gas}
+
+  """
+  @spec execute(binary(), non_neg_integer()) ::
+          {:ok, binary(), non_neg_integer()} | {:error, :out_of_gas}
+  def execute(input, gas_limit) do
+    cost = @base_cost + @word_cost * word_count(input)
+
+    if cost > gas_limit do
+      {:error, :out_of_gas}
+    else
+      {:ok, :crypto.hash(:sha256, input), cost}
+    end
+  end
+
+  # ceil(byte_size / 32) via the (n + 31) / 32 trick.
+  defp word_count(input), do: div(byte_size(input) + 31, 32)
+end

--- a/test/precompiles/sha256_test.exs
+++ b/test/precompiles/sha256_test.exs
@@ -1,0 +1,75 @@
+defmodule EEVM.Precompiles.SHA256Test do
+  use ExUnit.Case, async: true
+
+  alias EEVM.Precompiles.SHA256
+
+  # SHA-256 test vectors from NIST FIPS 180-4.
+  @empty_hash "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  @hello_hash "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+  @abc_hash "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+
+  describe "execute/2" do
+    test "empty input returns 32-byte digest" do
+      assert {:ok, digest, _gas} = SHA256.execute(<<>>, 1_000)
+      assert byte_size(digest) == 32
+    end
+
+    test "empty input matches NIST vector" do
+      assert {:ok, digest, _gas} = SHA256.execute(<<>>, 1_000)
+      assert Base.encode16(digest, case: :lower) == @empty_hash
+    end
+
+    test "sha256 of hello matches NIST vector" do
+      assert {:ok, digest, _gas} = SHA256.execute("hello", 1_000)
+      assert Base.encode16(digest, case: :lower) == @hello_hash
+    end
+
+    test "sha256 of abc matches NIST vector" do
+      assert {:ok, digest, _gas} = SHA256.execute("abc", 1_000)
+      assert Base.encode16(digest, case: :lower) == @abc_hash
+    end
+
+    test "empty input costs 60 gas (base only, 0 words)" do
+      assert {:ok, _, 60} = SHA256.execute(<<>>, 1_000)
+    end
+
+    test "1-byte input costs 72 gas (base 60 + 1 word × 12)" do
+      assert {:ok, _, 72} = SHA256.execute(<<0x01>>, 1_000)
+    end
+
+    test "exact 32-byte input costs 72 gas (1 word)" do
+      input = :binary.copy(<<0xAB>>, 32)
+      assert {:ok, _, 72} = SHA256.execute(input, 1_000)
+    end
+
+    test "33-byte input costs 84 gas (2 words)" do
+      input = :binary.copy(<<0x01>>, 33)
+      assert {:ok, _, 84} = SHA256.execute(input, 1_000)
+    end
+
+    test "out of gas when gas_limit < 60 on empty input" do
+      assert {:error, :out_of_gas} = SHA256.execute(<<>>, 59)
+    end
+
+    test "out of gas when gas_limit < cost for non-empty input" do
+      # 32-byte input costs 72; 71 gas is not enough
+      input = :binary.copy(<<0x00>>, 32)
+      assert {:error, :out_of_gas} = SHA256.execute(input, 71)
+    end
+
+    test "exact gas_limit equal to cost succeeds" do
+      assert {:ok, _, 60} = SHA256.execute(<<>>, 60)
+    end
+  end
+
+  describe "EEVM.Precompiles dispatcher" do
+    test "routes address 0x02 to SHA256" do
+      assert {:ok, digest, _} = EEVM.Precompiles.execute(0x02, "hello", 1_000)
+      assert Base.encode16(digest, case: :lower) == @hello_hash
+    end
+
+    test "unknown address falls through to not_implemented" do
+      assert {:error, :not_implemented} = EEVM.Precompiles.execute(0x99, <<>>, 1_000)
+    end
+  end
+end


### PR DESCRIPTION
Implements the SHA-256 precompile per Yellow Paper §E.2. SHA-256 is included for Bitcoin interoperability — Bitcoin addresses and block headers are SHA-256 based, enabling on-chain light-client verification without trusting off-chain computation.

## What

- `EEVM.Precompiles.SHA256` — executes the precompile via Erlang's `:crypto` NIF, charges gas, returns 32-byte digest
- `EEVM.Precompiles` — dispatcher module routing address `0x02` to SHA256
- `test/precompiles/sha256_test.exs` — full test coverage including NIST vectors

## Gas schedule

| Component | Cost |
|-----------|------|
| Base | 60 |
| Per word | 12 (32-byte chunks, rounded up) |

## Tests

- NIST FIPS 180-4 vectors: empty, `"hello"`, `"abc"`
- Output always 32 bytes
- Word-boundary gas: empty (60), 1 byte (72), 32 bytes (72), 33 bytes (84)
- Out-of-gas below threshold
- Exact gas_limit equal to cost
- Dispatcher routing for `0x02` and unknown address

Closes #43