### PR TITLE
feat(precompiles): add RIPEMD-160 precompile (address 0x03)

### DIFF
--- a/lib/eevm/precompiles.ex
+++ b/lib/eevm/precompiles.ex
@@ -1,12 +1,16 @@
 defmodule EEVM.Precompiles do
   @moduledoc false
 
+  alias EEVM.Precompiles.RIPEMD160
+
   @spec is_precompile?(non_neg_integer()) :: boolean()
   def is_precompile?(address) when address >= 0x01 and address <= 0x0A, do: true
   def is_precompile?(_), do: false
 
   @spec execute(non_neg_integer(), binary(), non_neg_integer()) ::
           {:ok, binary(), non_neg_integer()} | {:error, atom()}
+  def execute(0x03, input, gas_limit), do: RIPEMD160.execute(input, gas_limit)
+
   def execute(address, input, gas_limit) do
     :erlang.apply(__MODULE__, :do_execute, [address, input, gas_limit])
   end

--- a/lib/eevm/precompiles/ripemd160.ex
+++ b/lib/eevm/precompiles/ripemd160.ex
@@ -1,0 +1,83 @@
+defmodule EEVM.Precompiles.RIPEMD160 do
+  @moduledoc """
+  RIPEMD-160 precompile — address `0x03`.
+
+  ## EVM Concepts
+
+  RIPEMD-160 is a 160-bit (20-byte) cryptographic hash function developed in
+  Europe as an alternative to SHA-1. Its primary use in Ethereum is
+  **Bitcoin address derivation**: a Bitcoin address is `RIPEMD160(SHA256(pubkey))`,
+  so on-chain Bitcoin light-client contracts need this precompile to reconstruct
+  and verify addresses without trusting off-chain computation.
+
+  ### Output format (Yellow Paper §E.2)
+
+  Even though the digest is only 20 bytes, the precompile **always returns
+  32 bytes**: the 20-byte hash is **right-aligned** within the 32-byte word,
+  with 12 zero bytes prepended on the left. This matches the EVM's natural
+  word size and lets callers use the result directly as a `bytes32` or `address`
+  value without extra masking.
+
+  ```
+  [ 0x00 × 12 | RIPEMD160(input) × 20 ]
+  └────────────────────────── 32 bytes ──┘
+  ```
+
+  ### Gas schedule
+
+  | Component | Cost |
+  |-----------|------|
+  | Base      | 600  |
+  | Per word  | 120 (one word = 32 bytes, rounded up) |
+
+  The higher base cost reflects the fact that RIPEMD-160 is slower than both
+  Keccak-256 and SHA-256 in typical hardware implementations.
+
+  ## Elixir Learning Notes
+
+  - `:crypto.hash(:ripemd160, data)` produces a 20-byte binary. Erlang's
+    `:crypto` NIF supports RIPEMD-160 via OpenSSL.
+  - `<<0::96, hash::binary>>` is binary construction syntax. `0::96` emits
+    96 zero bits (= 12 zero bytes), and `hash::binary` appends the raw hash
+    bytes, yielding the required 32-byte output in one expression.
+  """
+
+  @base_cost 600
+  @word_cost 120
+
+  @doc """
+  Executes the RIPEMD-160 precompile.
+
+  Hashes `input` with RIPEMD-160 and returns a 32-byte binary: 12 zero bytes
+  followed by the 20-byte digest. Gas charged is
+  `600 + 120 * ceil(byte_size(input) / 32)`.
+
+  ## Examples
+
+      iex> {:ok, out, _gas} = EEVM.Precompiles.RIPEMD160.execute(<<>>, 10_000)
+      iex> byte_size(out)
+      32
+      iex> binary_part(out, 0, 12)
+      <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
+
+      iex> EEVM.Precompiles.RIPEMD160.execute(<<1::256>>, 5)
+      {:error, :out_of_gas}
+
+  """
+  @spec execute(binary(), non_neg_integer()) ::
+          {:ok, binary(), non_neg_integer()} | {:error, :out_of_gas}
+  def execute(input, gas_limit) do
+    cost = @base_cost + @word_cost * word_count(input)
+
+    if cost > gas_limit do
+      {:error, :out_of_gas}
+    else
+      hash = :crypto.hash(:ripemd160, input)
+      # Left-pad the 20-byte digest with 12 zero bytes to fill a 32-byte word.
+      {:ok, <<0::96, hash::binary>>, cost}
+    end
+  end
+
+  # ceil(byte_size / 32) via the (n + 31) / 32 trick.
+  defp word_count(input), do: div(byte_size(input) + 31, 32)
+end

--- a/test/precompiles/ripemd160_test.exs
+++ b/test/precompiles/ripemd160_test.exs
@@ -1,0 +1,84 @@
+defmodule EEVM.Precompiles.RIPEMD160Test do
+  use ExUnit.Case, async: true
+
+  alias EEVM.Precompiles.RIPEMD160
+
+  # RIPEMD-160 test vectors from the reference implementation.
+  @empty_hash "9c1185a5c5e9fc54612808977ee8f548b2258d31"
+  @abc_hash "8eb208f7e05d987a9b044a8e98c6b087f15a0bfc"
+  @hello_hash "108f07b8382412612c048d07d13f814118445acd"
+
+  describe "execute/2" do
+    test "output is always 32 bytes" do
+      assert {:ok, out, _gas} = RIPEMD160.execute(<<>>, 10_000)
+      assert byte_size(out) == 32
+    end
+
+    test "first 12 bytes are always zero (left-padding)" do
+      assert {:ok, out, _gas} = RIPEMD160.execute("anything", 10_000)
+      assert binary_part(out, 0, 12) == <<0::96>>
+    end
+
+    test "empty input matches reference vector" do
+      assert {:ok, out, _gas} = RIPEMD160.execute(<<>>, 10_000)
+      hash_hex = out |> binary_part(12, 20) |> Base.encode16(case: :lower)
+      assert hash_hex == @empty_hash
+    end
+
+    test "ripemd160 of abc matches reference vector" do
+      assert {:ok, out, _gas} = RIPEMD160.execute("abc", 10_000)
+      hash_hex = out |> binary_part(12, 20) |> Base.encode16(case: :lower)
+      assert hash_hex == @abc_hash
+    end
+
+    test "ripemd160 of hello matches reference vector" do
+      assert {:ok, out, _gas} = RIPEMD160.execute("hello", 10_000)
+      hash_hex = out |> binary_part(12, 20) |> Base.encode16(case: :lower)
+      assert hash_hex == @hello_hash
+    end
+
+    test "empty input costs 600 gas (base only, 0 words)" do
+      assert {:ok, _, 600} = RIPEMD160.execute(<<>>, 10_000)
+    end
+
+    test "1-byte input costs 720 gas (base 600 + 1 word × 120)" do
+      assert {:ok, _, 720} = RIPEMD160.execute(<<0x01>>, 10_000)
+    end
+
+    test "exact 32-byte input costs 720 gas (1 word)" do
+      input = :binary.copy(<<0xAB>>, 32)
+      assert {:ok, _, 720} = RIPEMD160.execute(input, 10_000)
+    end
+
+    test "33-byte input costs 840 gas (2 words)" do
+      input = :binary.copy(<<0x01>>, 33)
+      assert {:ok, _, 840} = RIPEMD160.execute(input, 10_000)
+    end
+
+    test "out of gas when gas_limit < 600 on empty input" do
+      assert {:error, :out_of_gas} = RIPEMD160.execute(<<>>, 599)
+    end
+
+    test "out of gas when gas_limit < cost for non-empty input" do
+      # 32-byte input costs 720; 719 gas is not enough
+      input = :binary.copy(<<0x00>>, 32)
+      assert {:error, :out_of_gas} = RIPEMD160.execute(input, 719)
+    end
+
+    test "exact gas_limit equal to cost succeeds" do
+      assert {:ok, _, 600} = RIPEMD160.execute(<<>>, 600)
+    end
+  end
+
+  describe "EEVM.Precompiles dispatcher" do
+    test "routes address 0x03 to RIPEMD160" do
+      assert {:ok, out, _} = EEVM.Precompiles.execute(0x03, "abc", 10_000)
+      hash_hex = out |> binary_part(12, 20) |> Base.encode16(case: :lower)
+      assert hash_hex == @abc_hash
+    end
+
+    test "unknown address falls through to not_implemented" do
+      assert {:error, :not_implemented} = EEVM.Precompiles.execute(0x99, <<>>, 10_000)
+    end
+  end
+end


### PR DESCRIPTION
Implements the RIPEMD-160 precompile per Yellow Paper §E.2. RIPEMD-160 is used for Bitcoin address derivation (`RIPEMD160(SHA256(pubkey))`), enabling on-chain Bitcoin address verification.

## What

- `EEVM.Precompiles.RIPEMD160` — executes the precompile via Erlang's `:crypto` NIF, left-pads the 20-byte digest to 32 bytes, charges gas
- `EEVM.Precompiles` — dispatcher module routing address `0x03` to RIPEMD160
- `test/precompiles/ripemd160_test.exs` — full test coverage including reference vectors

## Gas schedule

| Component | Cost |
|-----------|------|
| Base | 600 |
| Per word | 120 (32-byte chunks, rounded up) |

## Output format

Always 32 bytes: 12 zero bytes + 20-byte RIPEMD-160 digest (right-aligned in EVM word). Constructed as `<<0::96, hash::binary>>`.

## Tests

- Reference vectors: empty (`9c1185a5...`), `"abc"` (`8eb208f7...`), `"hello"` (`108f07b8...`)
- Output always 32 bytes invariant
- First 12 bytes always zero invariant
- Word-boundary gas: empty (600), 1 byte (720), 32 bytes (720), 33 bytes (840)
- Out-of-gas below threshold
- Exact gas_limit equal to cost
- Dispatcher routing for `0x03` and unknown address

Closes #44