### PR TITLE
feat(gas): implement SSTORE gas schedule (EIP-2200 + EIP-3529)

### DIFF
--- a/lib/eevm/gas/dynamic.ex
+++ b/lib/eevm/gas/dynamic.ex
@@ -13,6 +13,10 @@ defmodule EEVM.Gas.Dynamic do
   @gas_code_deposit 200
   @gas_call_value 9000
   @gas_new_account 25_000
+  @sstore_set_gas 20_000
+  @sstore_reset_gas 2_900
+  @sstore_clears_schedule 4_800
+  @sstore_noop_gas 100
 
   @spec exp_dynamic_cost(non_neg_integer()) :: non_neg_integer()
   def exp_dynamic_cost(0), do: 0
@@ -55,6 +59,56 @@ defmodule EEVM.Gas.Dynamic do
   @spec call_stipend(non_neg_integer()) :: non_neg_integer()
   def call_stipend(0), do: 0
   def call_stipend(_value), do: 2300
+
+  @spec sstore_cost(non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
+          {non_neg_integer(), integer()}
+  def sstore_cost(original, current, new_value) do
+    cond do
+      current == new_value ->
+        {@sstore_noop_gas, 0}
+
+      original == current and original == 0 ->
+        {@sstore_set_gas, 0}
+
+      original == current ->
+        refund = if new_value == 0, do: @sstore_clears_schedule, else: 0
+        {@sstore_reset_gas, refund}
+
+      true ->
+        refund = dirty_slot_refund_delta(original, current, new_value)
+        {@sstore_noop_gas, refund}
+    end
+  end
+
+  @spec sstore_cost(non_neg_integer(), non_neg_integer(), non_neg_integer(), boolean()) ::
+          {non_neg_integer(), integer()}
+  def sstore_cost(original, current, new_value, _is_warm),
+    do: sstore_cost(original, current, new_value)
+
+  defp dirty_slot_refund_delta(original, current, new_value) do
+    base_refund =
+      if original != 0 do
+        0
+        |> maybe_subtract(current == 0, @sstore_clears_schedule)
+        |> maybe_add(new_value == 0, @sstore_clears_schedule)
+      else
+        0
+      end
+
+    if original == new_value do
+      if original == 0,
+        do: base_refund + (@sstore_set_gas - @sstore_noop_gas),
+        else: base_refund + (@sstore_reset_gas - @sstore_noop_gas)
+    else
+      base_refund
+    end
+  end
+
+  defp maybe_add(value, true, amount), do: value + amount
+  defp maybe_add(value, false, _amount), do: value
+
+  defp maybe_subtract(value, true, amount), do: value - amount
+  defp maybe_subtract(value, false, _amount), do: value
 
   defp word_count(0), do: 0
   defp word_count(byte_size), do: div(byte_size + 31, 32)

--- a/lib/eevm/gas/static.ex
+++ b/lib/eevm/gas/static.ex
@@ -10,7 +10,6 @@ defmodule EEVM.Gas.Static do
   @gas_jumpdest 1
 
   @gas_keccak256 30
-  @gas_sstore 20_000
   @gas_blockhash 20
   @gas_selfbalance 5
   @gas_log 375
@@ -83,7 +82,7 @@ defmodule EEVM.Gas.Static do
   def static_cost(0x52), do: @gas_very_low
   def static_cost(0x53), do: @gas_very_low
   def static_cost(0x54), do: 0
-  def static_cost(0x55), do: @gas_sstore
+  def static_cost(0x55), do: 0
   def static_cost(0x56), do: @gas_mid
   def static_cost(0x57), do: @gas_high
   def static_cost(0x58), do: @gas_base

--- a/lib/eevm/machine_state.ex
+++ b/lib/eevm/machine_state.ex
@@ -35,6 +35,7 @@ defmodule EEVM.MachineState do
           stack: Stack.t(),
           memory: Memory.t(),
           storage: Storage.t(),
+          original_storage: %{non_neg_integer() => non_neg_integer()},
           transient_storage: %{non_neg_integer() => non_neg_integer()},
           tx: Transaction.t(),
           block: Block.t(),
@@ -48,6 +49,7 @@ defmodule EEVM.MachineState do
           is_static: boolean(),
           depth: non_neg_integer(),
           gas: non_neg_integer(),
+          refund: non_neg_integer(),
           status: status(),
           return_data: binary(),
           logs: [%{address: non_neg_integer(), data: binary(), topics: [non_neg_integer()]}],
@@ -59,6 +61,7 @@ defmodule EEVM.MachineState do
             stack: nil,
             memory: nil,
             storage: nil,
+            original_storage: %{},
             transient_storage: %{},
             tx: nil,
             block: nil,
@@ -72,6 +75,7 @@ defmodule EEVM.MachineState do
             is_static: false,
             depth: 0,
             gas: 1_000_000,
+            refund: 0,
             status: :running,
             return_data: <<>>,
             logs: [],
@@ -111,6 +115,7 @@ defmodule EEVM.MachineState do
       stack: Stack.new(),
       memory: Memory.new(),
       storage: Keyword.get(opts, :storage, Storage.new()),
+      original_storage: Keyword.get(opts, :original_storage, %{}),
       transient_storage: Keyword.get(opts, :transient_storage, %{}),
       tx: tx,
       block: Keyword.get(opts, :block, Block.new()),
@@ -125,7 +130,8 @@ defmodule EEVM.MachineState do
       is_static: Keyword.get(opts, :is_static, false),
       depth: Keyword.get(opts, :depth, 0),
       return_data: Keyword.get(opts, :return_data, <<>>),
-      gas: Keyword.get(opts, :gas, 1_000_000)
+      gas: Keyword.get(opts, :gas, 1_000_000),
+      refund: Keyword.get(opts, :refund, 0)
     }
   end
 
@@ -269,6 +275,14 @@ defmodule EEVM.MachineState do
   @doc "Returns the gas remaining."
   @spec gas_remaining(t()) :: non_neg_integer()
   def gas_remaining(%__MODULE__{gas: gas}), do: gas
+
+  @doc "Adds `amount` to the accumulated gas refund."
+  @spec add_refund(t(), non_neg_integer()) :: t()
+  def add_refund(state, amount), do: %{state | refund: state.refund + amount}
+
+  @doc "Subtracts `amount` from refund, flooring at 0."
+  @spec sub_refund(t(), non_neg_integer()) :: t()
+  def sub_refund(state, amount), do: %{state | refund: max(state.refund - amount, 0)}
 
   @doc "Halts execution with the given status."
   @spec halt(t(), status()) :: t()

--- a/lib/eevm/opcodes/stack_memory_storage/storage_ops.ex
+++ b/lib/eevm/opcodes/stack_memory_storage/storage_ops.ex
@@ -2,7 +2,9 @@ defmodule EEVM.Opcodes.StackMemoryStorage.StorageOps do
   @moduledoc false
 
   alias EEVM.{MachineState, Stack, Storage}
-  alias EEVM.Gas.Access
+  alias EEVM.Gas.{Access, Dynamic}
+
+  @cold_sload_cost 2100
 
   @spec execute(non_neg_integer(), MachineState.t()) ::
           {:ok, MachineState.t()} | {:error, atom(), MachineState.t()}
@@ -33,8 +35,38 @@ defmodule EEVM.Opcodes.StackMemoryStorage.StorageOps do
   def execute(0x55, state) do
     with {:ok, key, s1} <- Stack.pop(state.stack),
          {:ok, value, s2} <- Stack.pop(s1) do
-      new_storage = Storage.store(state.storage, key, value)
-      {:ok, %{state | stack: s2, storage: new_storage} |> MachineState.advance_pc()}
+      state_after_stack = %{state | stack: s2}
+      contract_address = state_after_stack.contract.address
+      access_key = {contract_address, key}
+      is_warm = MapSet.member?(state_after_stack.accessed_storage_keys, access_key)
+
+      state_after_access =
+        if is_warm do
+          state_after_stack
+        else
+          %{
+            state_after_stack
+            | accessed_storage_keys:
+                MapSet.put(state_after_stack.accessed_storage_keys, access_key)
+          }
+        end
+
+      cold_cost = if is_warm, do: 0, else: @cold_sload_cost
+      {original_value, state_with_original} = get_original_value(state_after_access, key)
+      current_value = Storage.load(state_with_original.storage, key)
+
+      {sstore_gas, refund_delta} = Dynamic.sstore_cost(original_value, current_value, value)
+      total_cost = cold_cost + sstore_gas
+
+      case MachineState.consume_gas(state_with_original, total_cost) do
+        {:ok, state_after_gas} ->
+          state_after_refund = apply_refund_delta(state_after_gas, refund_delta)
+          new_storage = Storage.store(state_after_refund.storage, key, value)
+          {:ok, %{state_after_refund | storage: new_storage} |> MachineState.advance_pc()}
+
+        {:error, :out_of_gas, halted} ->
+          {:error, :out_of_gas, halted}
+      end
     else
       {:error, reason} -> {:error, reason, state}
     end
@@ -61,4 +93,23 @@ defmodule EEVM.Opcodes.StackMemoryStorage.StorageOps do
   end
 
   def execute(_opcode, state), do: {:ok, MachineState.halt(state, :invalid)}
+
+  defp get_original_value(state, key) do
+    case Map.fetch(state.original_storage, key) do
+      {:ok, value} ->
+        {value, state}
+
+      :error ->
+        value = Storage.load(state.storage, key)
+        {value, %{state | original_storage: Map.put(state.original_storage, key, value)}}
+    end
+  end
+
+  defp apply_refund_delta(state, refund_delta) when refund_delta > 0,
+    do: MachineState.add_refund(state, refund_delta)
+
+  defp apply_refund_delta(state, refund_delta) when refund_delta < 0,
+    do: MachineState.sub_refund(state, abs(refund_delta))
+
+  defp apply_refund_delta(state, 0), do: state
 end

--- a/test/opcodes/sstore_gas_test.exs
+++ b/test/opcodes/sstore_gas_test.exs
@@ -1,0 +1,127 @@
+defmodule EEVM.Opcodes.SstoreGasTest do
+  use ExUnit.Case, async: true
+
+  alias EEVM.Storage
+
+  describe "SSTORE gas schedule (EIP-2200 + EIP-3529)" do
+    test "no-op SSTORE (current == new) costs 100 gas on warm slot" do
+      code = <<0x60, 0x07, 0x60, 0x00, 0x55, 0x00>>
+
+      result =
+        EEVM.execute(code,
+          gas: 10_000,
+          storage: Storage.new(%{0 => 7}),
+          accessed_storage_keys: MapSet.new([{0, 0}])
+        )
+
+      assert result.gas == 10_000 - 3 - 3 - 100
+      assert result.refund == 0
+    end
+
+    test "fresh write (0 -> nonzero) on clean slot costs 20_000" do
+      code = <<0x60, 0x01, 0x60, 0x00, 0x55, 0x00>>
+
+      result =
+        EEVM.execute(code,
+          gas: 30_000,
+          accessed_storage_keys: MapSet.new([{0, 0}])
+        )
+
+      assert result.gas == 30_000 - 3 - 3 - 20_000
+      assert result.refund == 0
+    end
+
+    test "clean update (nonzero -> different nonzero) costs 2_900" do
+      code = <<0x60, 0x09, 0x60, 0x00, 0x55, 0x00>>
+
+      result =
+        EEVM.execute(code,
+          gas: 10_000,
+          storage: Storage.new(%{0 => 7}),
+          accessed_storage_keys: MapSet.new([{0, 0}])
+        )
+
+      assert result.gas == 10_000 - 3 - 3 - 2_900
+      assert result.refund == 0
+    end
+
+    test "clean clear (nonzero -> 0) costs 2_900 and adds 4_800 refund" do
+      code = <<0x60, 0x00, 0x60, 0x00, 0x55, 0x00>>
+
+      result =
+        EEVM.execute(code,
+          gas: 10_000,
+          storage: Storage.new(%{0 => 7}),
+          accessed_storage_keys: MapSet.new([{0, 0}])
+        )
+
+      assert result.gas == 10_000 - 3 - 3 - 2_900
+      assert result.refund == 4_800
+    end
+
+    test "dirty slot rewrite costs 100" do
+      code =
+        <<0x60, 0x07, 0x60, 0x00, 0x55>> <>
+          <<0x60, 0x09, 0x60, 0x00, 0x55, 0x00>>
+
+      result =
+        EEVM.execute(code,
+          gas: 20_000,
+          storage: Storage.new(%{0 => 5})
+        )
+
+      assert result.gas == 20_000 - (3 + 3 + 2_100 + 2_900) - (3 + 3 + 100)
+      assert result.refund == 0
+    end
+
+    test "dirty slot reset to original nonzero adds 2_800 refund" do
+      code = <<0x60, 0x05, 0x60, 0x00, 0x55, 0x00>>
+
+      result =
+        EEVM.execute(code,
+          gas: 10_000,
+          storage: Storage.new(%{0 => 7}),
+          original_storage: %{0 => 5},
+          accessed_storage_keys: MapSet.new([{0, 0}])
+        )
+
+      assert result.gas == 10_000 - 3 - 3 - 100
+      assert result.refund == 2_800
+    end
+
+    test "dirty slot reset to original zero adds 19_900 refund" do
+      code = <<0x60, 0x00, 0x60, 0x00, 0x55, 0x00>>
+
+      result =
+        EEVM.execute(code,
+          gas: 30_000,
+          storage: Storage.new(%{0 => 7}),
+          original_storage: %{0 => 0},
+          accessed_storage_keys: MapSet.new([{0, 0}])
+        )
+
+      assert result.gas == 30_000 - 3 - 3 - 100
+      assert result.refund == 19_900
+    end
+
+    test "cold slot access adds 2_100 surcharge" do
+      code = <<0x60, 0x07, 0x60, 0x00, 0x55, 0x00>>
+
+      result = EEVM.execute(code, gas: 10_000, storage: Storage.new(%{0 => 7}))
+
+      assert result.gas == 10_000 - 3 - 3 - 2_100 - 100
+      assert result.refund == 0
+    end
+
+    test "warm second access has no extra surcharge" do
+      code =
+        <<0x60, 0x07, 0x60, 0x00, 0x55>> <>
+          <<0x60, 0x07, 0x60, 0x00, 0x55, 0x00>>
+
+      result = EEVM.execute(code, gas: 10_000, storage: Storage.new(%{0 => 7}))
+
+      assert result.gas == 10_000 - (3 + 3 + 2_100 + 100) - (3 + 3 + 100)
+      assert result.refund == 0
+    end
+  end
+end

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -52,12 +52,11 @@ defmodule EEVM.StorageTest do
       assert EEVM.stack_values(result) == [9999]
     end
 
-    test "SSTORE gas cost is 20000" do
+    test "SSTORE fresh write includes cold surcharge" do
       # PUSH1 1, PUSH1 0, SSTORE, STOP
-      # Gas: PUSH1=3 + PUSH1=3 + SSTORE=20000 + STOP=0 = 20006
       code = <<0x60, 1, 0x60, 0, 0x55, 0x00>>
       result = EEVM.execute(code, gas: 100_000)
-      assert result.gas == 100_000 - 20_006
+      assert result.gas == 100_000 - 22_106
     end
 
     test "SLOAD cold gas cost is 2100" do


### PR DESCRIPTION
Replace flat 20,000 gas cost with full state-machine pricing based on
original, current, and new slot values per EIP-2200/EIP-3529.

- Add original_storage and refund fields to MachineState for tracking
  slot values at transaction start and accumulating refund deltas
- Implement sstore_cost/3 in Gas.Dynamic with all state transitions:
  no-op (100), fresh write (20,000), clean update (2,900),
  clean clear (2,900 + 4,800 refund), dirty slot (100),
  and reset-to-original refund adjustments (2,800/19,900)
- Update StorageOps to use dynamic SSTORE costing with cold/warm
  access surcharges via EIP-2929 access list integration
- Change static_cost(0x55) from 20,000 to 0 (fully dynamic)
- Add comprehensive tests covering all SSTORE state transitions

Closes #39