### PR TITLE
feat(selfdestruct): implement EIP-6780 same-transaction deletion semantics

### DIFF
--- a/lib/eevm/machine_state.ex
+++ b/lib/eevm/machine_state.ex
@@ -42,6 +42,7 @@ defmodule EEVM.MachineState do
           contract: Contract.t(),
           accessed_addresses: MapSet.t(non_neg_integer()),
           accessed_storage_keys: MapSet.t({non_neg_integer(), non_neg_integer()}),
+          created_addresses: MapSet.t(non_neg_integer()),
           world_state: WorldState.t(),
           call_stack: [CallFrame.t()],
           frame_return_offset: non_neg_integer(),
@@ -68,6 +69,7 @@ defmodule EEVM.MachineState do
             contract: nil,
             accessed_addresses: nil,
             accessed_storage_keys: nil,
+            created_addresses: nil,
             world_state: nil,
             call_stack: [],
             frame_return_offset: 0,
@@ -124,6 +126,7 @@ defmodule EEVM.MachineState do
       accessed_addresses:
         Keyword.get(opts, :accessed_addresses, pre_warm_addresses(contract, tx)),
       accessed_storage_keys: Keyword.get(opts, :accessed_storage_keys, MapSet.new()),
+      created_addresses: Keyword.get(opts, :created_addresses, MapSet.new()),
       world_state: Keyword.get(opts, :world_state, WorldState.new()),
       call_stack: Keyword.get(opts, :call_stack, []),
       frame_return_offset: Keyword.get(opts, :frame_return_offset, 0),

--- a/lib/eevm/memory.ex
+++ b/lib/eevm/memory.ex
@@ -6,7 +6,7 @@ defmodule EEVM.Memory do
 
   - Memory is a word-addressed byte array that expands in 32-byte chunks.
   - Reading/writing beyond current size auto-expands (zero-filled).
-  - Gas cost increases quadratically with memory size (not implemented yet).
+  - Gas cost increases quadratically with memory size (see `EEVM.Gas.Memory`).
 
   ## Elixir Learning Notes
 

--- a/lib/eevm/opcodes/system/calls.ex
+++ b/lib/eevm/opcodes/system/calls.ex
@@ -242,6 +242,7 @@ defmodule EEVM.Opcodes.System.Calls do
                 world_state: world_state_after_transfer,
                 accessed_addresses: state_after_forward.accessed_addresses,
                 accessed_storage_keys: state_after_forward.accessed_storage_keys,
+                created_addresses: state_after_forward.created_addresses,
                 is_static: state_after_forward.is_static,
                 depth: state_after_forward.depth + 1
               )
@@ -274,6 +275,11 @@ defmodule EEVM.Opcodes.System.Calls do
                 do: child_result.accessed_storage_keys,
                 else: state_after_forward.accessed_storage_keys
 
+            created_addresses_result =
+              if call_succeeded,
+                do: child_result.created_addresses,
+                else: state_after_forward.created_addresses
+
             memory_result =
               write_return_data(memory_after_read, ret_offset, ret_size, child_result.return_data)
 
@@ -290,6 +296,7 @@ defmodule EEVM.Opcodes.System.Calls do
              |> Map.put(:logs, logs_result)
              |> Map.put(:accessed_addresses, accessed_addresses_result)
              |> Map.put(:accessed_storage_keys, accessed_storage_keys_result)
+             |> Map.put(:created_addresses, created_addresses_result)
              |> Map.put(:gas, state_after_forward.gas + child_result.gas)
              |> MachineState.advance_pc()}
           end
@@ -386,6 +393,7 @@ defmodule EEVM.Opcodes.System.Calls do
                 world_state: state_after_forward.world_state,
                 accessed_addresses: state_after_forward.accessed_addresses,
                 accessed_storage_keys: state_after_forward.accessed_storage_keys,
+                created_addresses: state_after_forward.created_addresses,
                 is_static: state_after_forward.is_static,
                 depth: state_after_forward.depth + 1
               )
@@ -418,6 +426,11 @@ defmodule EEVM.Opcodes.System.Calls do
                 do: child_result.accessed_storage_keys,
                 else: state_after_forward.accessed_storage_keys
 
+            created_addresses_result =
+              if call_succeeded,
+                do: child_result.created_addresses,
+                else: state_after_forward.created_addresses
+
             memory_result =
               write_return_data(memory_after_read, ret_offset, ret_size, child_result.return_data)
 
@@ -434,6 +447,7 @@ defmodule EEVM.Opcodes.System.Calls do
              |> Map.put(:logs, logs_result)
              |> Map.put(:accessed_addresses, accessed_addresses_result)
              |> Map.put(:accessed_storage_keys, accessed_storage_keys_result)
+             |> Map.put(:created_addresses, created_addresses_result)
              |> Map.put(:gas, state_after_forward.gas + child_result.gas)
              |> MachineState.advance_pc()}
           end

--- a/lib/eevm/opcodes/system/creation.ex
+++ b/lib/eevm/opcodes/system/creation.ex
@@ -115,6 +115,7 @@ defmodule EEVM.Opcodes.System.Creation do
                         world_state: world_state_after_transfer,
                         accessed_addresses: state_after_initcode_cost.accessed_addresses,
                         accessed_storage_keys: state_after_initcode_cost.accessed_storage_keys,
+                        created_addresses: state_after_initcode_cost.created_addresses,
                         is_static: state_after_initcode_cost.is_static,
                         depth: state_after_initcode_cost.depth + 1
                       )
@@ -141,6 +142,9 @@ defmodule EEVM.Opcodes.System.Creation do
 
                           {:ok, stack_after_create} = Stack.push(stack, new_address)
 
+                          created_addresses_after =
+                            MapSet.put(child_result.created_addresses, new_address)
+
                           {:ok,
                            state_after_initcode_cost
                            |> Map.put(:stack, stack_after_create)
@@ -150,6 +154,7 @@ defmodule EEVM.Opcodes.System.Creation do
                            |> Map.put(:logs, state_after_initcode_cost.logs ++ child_result.logs)
                            |> Map.put(:accessed_addresses, child_result.accessed_addresses)
                            |> Map.put(:accessed_storage_keys, child_result.accessed_storage_keys)
+                           |> Map.put(:created_addresses, created_addresses_after)
                            |> Map.put(:gas, child_result.gas - deposit_cost)
                            |> Map.put(:return_data, child_result.return_data)
                            |> MachineState.advance_pc()}

--- a/lib/eevm/opcodes/system/termination.ex
+++ b/lib/eevm/opcodes/system/termination.ex
@@ -65,16 +65,38 @@ defmodule EEVM.Opcodes.System.Termination do
 
       case MachineState.consume_gas(%{state | stack: s1}, dynamic_cost) do
         {:ok, state_after_gas} ->
-          world_state_zeroed =
-            state_after_gas.world_state
-            |> WorldState.set_balance(contract_address, 0)
+          # EIP-6780: post-Cancun, SELFDESTRUCT only fully deletes the account
+          # when the contract was created in the same transaction. Otherwise it
+          # only transfers the balance to the beneficiary.
+          created_this_tx =
+            MapSet.member?(state_after_gas.created_addresses, contract_address)
 
           world_state_after =
-            world_state_zeroed
-            |> WorldState.set_balance(
-              beneficiary,
-              WorldState.get_balance(world_state_zeroed, beneficiary) + balance
-            )
+            if created_this_tx do
+              # EIP-6780: full deletion for contracts created in the same tx
+              ws = WorldState.delete_account(state_after_gas.world_state, contract_address)
+
+              if beneficiary != contract_address do
+                WorldState.set_balance(
+                  ws,
+                  beneficiary,
+                  WorldState.get_balance(ws, beneficiary) + balance
+                )
+              else
+                ws
+              end
+            else
+              if beneficiary == contract_address do
+                state_after_gas.world_state
+              else
+                beneficiary_balance =
+                  WorldState.get_balance(state_after_gas.world_state, beneficiary)
+
+                state_after_gas.world_state
+                |> WorldState.set_balance(contract_address, 0)
+                |> WorldState.set_balance(beneficiary, beneficiary_balance + balance)
+              end
+            end
 
           {:ok, MachineState.halt(%{state_after_gas | world_state: world_state_after}, :stopped)}
 

--- a/lib/eevm/world_state.ex
+++ b/lib/eevm/world_state.ex
@@ -82,6 +82,18 @@ defmodule EEVM.WorldState do
     %{world_state | accounts: Map.put(accounts, address, account)}
   end
 
+  @doc """
+  Removes an account entirely from the world state.
+
+  Used by SELFDESTRUCT under EIP-6780: when a contract is created and
+  self-destructed within the same transaction, the account is fully deleted
+  (balance, nonce, code, and storage are all removed).
+  """
+  @spec delete_account(t(), non_neg_integer()) :: t()
+  def delete_account(%__MODULE__{accounts: accounts} = world_state, address) do
+    %{world_state | accounts: Map.delete(accounts, address)}
+  end
+
   @spec put_code(t(), non_neg_integer(), binary()) :: t()
   def put_code(world_state, address, code) when is_binary(code) do
     update_account(world_state, address, fn account -> Map.put(account, :code, code) end)

--- a/test/opcodes/selfdestruct_test.exs
+++ b/test/opcodes/selfdestruct_test.exs
@@ -108,7 +108,7 @@ defmodule EEVM.Opcodes.SelfdestructTest do
       assert result.gas == expected_gas
     end
 
-    test "contract code/nonce/storage preserved (post-Cancun)" do
+    test "contract code/nonce/storage preserved (post-Cancun, not created this tx)" do
       world_state =
         WorldState.new(%{
           0xAA => %{balance: 50, code: <<0x60, 0x01>>, nonce: 5},
@@ -125,6 +125,67 @@ defmodule EEVM.Opcodes.SelfdestructTest do
       assert WorldState.get_nonce(result.world_state, 0xAA) == 5
       assert WorldState.get_balance(result.world_state, 0xAA) == 0
       assert WorldState.get_balance(result.world_state, 0xBB) == 50
+    end
+
+    test "EIP-6780: full deletion when contract was created in same tx" do
+      world_state =
+        WorldState.new(%{
+          0xAA => %{balance: 100, code: <<0x60, 0x01>>, nonce: 3},
+          0xBB => %{balance: 50}
+        })
+
+      contract = Contract.new(address: 0xAA)
+      code = <<0x60, 0xBB, 0xFF>>
+
+      result =
+        EEVM.execute(code,
+          world_state: world_state,
+          contract: contract,
+          created_addresses: MapSet.new([0xAA]),
+          gas: 1_000_000
+        )
+
+      assert result.status == :stopped
+      assert WorldState.get_account(result.world_state, 0xAA) == nil
+      assert WorldState.account_exists?(result.world_state, 0xAA) == false
+      assert WorldState.get_balance(result.world_state, 0xBB) == 150
+    end
+
+    test "EIP-6780: full deletion to self when created in same tx burns balance" do
+      world_state = WorldState.new(%{0xAA => %{balance: 100, code: <<0x60, 0x01>>, nonce: 1}})
+      contract = Contract.new(address: 0xAA)
+      code = <<0x60, 0xAA, 0xFF>>
+
+      result =
+        EEVM.execute(code,
+          world_state: world_state,
+          contract: contract,
+          created_addresses: MapSet.new([0xAA]),
+          gas: 1_000_000
+        )
+
+      assert result.status == :stopped
+      assert WorldState.get_account(result.world_state, 0xAA) == nil
+    end
+
+    test "EIP-6780: not created this tx preserves account (only transfers balance)" do
+      world_state =
+        WorldState.new(%{
+          0xAA => %{balance: 75, code: <<0xFE>>, nonce: 10},
+          0xCC => %{balance: 0}
+        })
+
+      contract = Contract.new(address: 0xAA)
+      code = <<0x60, 0xCC, 0xFF>>
+
+      result = EEVM.execute(code, world_state: world_state, contract: contract, gas: 1_000_000)
+
+      assert result.status == :stopped
+      assert WorldState.account_exists?(result.world_state, 0xAA) == true
+      assert WorldState.get_code(result.world_state, 0xAA) == <<0xFE>>
+      assert WorldState.get_nonce(result.world_state, 0xAA) == 10
+      assert WorldState.get_balance(result.world_state, 0xAA) == 0
+      assert WorldState.get_balance(result.world_state, 0xCC) == 75
     end
   end
 end


### PR DESCRIPTION
## Summary

- Implement full EIP-6780 SELFDESTRUCT semantics: contracts created in the same transaction are fully deleted (balance, code, nonce, storage removed), while pre-existing contracts only have their balance transferred to the beneficiary (SENDALL behavior)
- Add `created_addresses` tracking (MapSet) through CREATE/CREATE2, CALL, DELEGATECALL, and STATICCALL child frames
- Add `WorldState.delete_account/2` for complete account removal
- Fix SELFDESTRUCT-to-self edge cases for both deletion paths
- Fix stale comment in `memory.ex` claiming gas cost is not implemented

## Changes

| File | Change |
|------|--------|
| `machine_state.ex` | Add `created_addresses` field |
| `world_state.ex` | Add `delete_account/2` |
| `creation.ex` | Track newly created addresses, propagate through child frames |
| `calls.ex` | Propagate `created_addresses` in both `execute_call` and `execute_delegatecall` |
| `termination.ex` | Branch SELFDESTRUCT on `created_addresses` membership |
| `memory.ex` | Fix stale comment |
| `selfdestruct_test.exs` | 3 new EIP-6780 tests |

## Testing

- 352 tests, 0 failures (3 new)
- `mix quality` passes (credo, dialyzer, compile --warnings-as-errors)