### PR TITLE
feat: Add Database behaviour with swappable backend interface

### DIFF
--- a/lib/eevm/database.ex
+++ b/lib/eevm/database.ex
@@ -1,0 +1,224 @@
+defmodule EEVM.Database do
+  @moduledoc """
+  Behaviour defining the external state interface for the EVM.
+
+  ## EVM Concepts
+
+  The EVM requires access to two categories of persistent state during execution:
+
+  - **Account state** — balances, nonces, and bytecode for all addresses (the
+    "world state" in Yellow Paper terminology).
+  - **Contract storage** — per-contract key-value mappings of 256-bit slots.
+
+  This behaviour abstracts both behind a single interface, allowing different
+  backends (in-memory maps, Merkle-backed stores, databases) to be plugged in
+  without changing opcode implementations.
+
+  The default implementation is `EEVM.Database.InMemory`, which wraps the
+  existing `EEVM.WorldState` and `EEVM.Storage` modules.
+
+  ## Design
+
+  A database value is a `%EEVM.Database{}` struct containing:
+
+  - `impl` — the module implementing `@behaviour EEVM.Database`
+  - `state` — the implementation-specific state (opaque to callers)
+
+  All public functions in this module dispatch to the `impl` module, passing
+  and receiving the opaque `state`. This keeps opcode modules decoupled from
+  any particular storage backend.
+
+  ## Elixir Learning Notes
+
+  - **Behaviours** define a contract (set of callbacks) that implementing modules
+    must fulfill — similar to interfaces in OOP languages.
+  - The `%Database{}` struct acts as a "type-erased wrapper": callers interact
+    with it through this module's public API, while the actual work is done by
+    whatever module sits behind `impl`.
+  - This pattern avoids Protocols (which dispatch on the first argument's struct
+    type) because we want a single struct type (`%Database{}`) that can wrap
+    any backend.
+  """
+
+  @type account :: %{
+          optional(:balance) => non_neg_integer(),
+          optional(:nonce) => non_neg_integer(),
+          optional(:code) => binary(),
+          optional(:storage) => EEVM.Storage.t()
+        }
+
+  @type t :: %__MODULE__{
+          impl: module(),
+          state: term()
+        }
+
+  defstruct [:impl, :state]
+
+  # ---------------------------------------------------------------------------
+  # Account read callbacks
+  # ---------------------------------------------------------------------------
+
+  @doc "Fetch the full account record, or nil if the address has no state."
+  @callback get_account(state :: term(), address :: non_neg_integer()) :: account() | nil
+
+  @doc "Check whether an account exists at the given address."
+  @callback account_exists?(state :: term(), address :: non_neg_integer()) :: boolean()
+
+  @doc "Return the bytecode deployed at `address` (empty binary if none)."
+  @callback get_code(state :: term(), address :: non_neg_integer()) :: binary()
+
+  @doc "Return the balance in wei for `address` (0 if non-existent)."
+  @callback get_balance(state :: term(), address :: non_neg_integer()) :: non_neg_integer()
+
+  @doc "Return the nonce for `address` (0 if non-existent)."
+  @callback get_nonce(state :: term(), address :: non_neg_integer()) :: non_neg_integer()
+
+  # ---------------------------------------------------------------------------
+  # Account write callbacks
+  # ---------------------------------------------------------------------------
+
+  @doc "Replace the entire account record at `address`."
+  @callback put_account(state :: term(), address :: non_neg_integer(), account :: account()) ::
+              term()
+
+  @doc "Remove an account entirely (used by SELFDESTRUCT under EIP-6780)."
+  @callback delete_account(state :: term(), address :: non_neg_integer()) :: term()
+
+  @doc "Set the bytecode at `address`."
+  @callback put_code(state :: term(), address :: non_neg_integer(), code :: binary()) :: term()
+
+  @doc "Set the balance at `address`."
+  @callback set_balance(
+              state :: term(),
+              address :: non_neg_integer(),
+              balance :: non_neg_integer()
+            ) :: term()
+
+  @doc "Set the nonce at `address`."
+  @callback set_nonce(state :: term(), address :: non_neg_integer(), nonce :: non_neg_integer()) ::
+              term()
+
+  @doc "Increment the nonce at `address` by 1."
+  @callback increment_nonce(state :: term(), address :: non_neg_integer()) :: term()
+
+  @doc "Transfer `amount` wei from one address to another."
+  @callback transfer(
+              state :: term(),
+              from :: non_neg_integer(),
+              to :: non_neg_integer(),
+              amount :: non_neg_integer()
+            ) :: {:ok, term()} | {:error, :insufficient_balance}
+
+  # ---------------------------------------------------------------------------
+  # Storage callbacks
+  # ---------------------------------------------------------------------------
+
+  @doc "Load a 256-bit storage slot for the given contract address."
+  @callback storage_load(
+              state :: term(),
+              address :: non_neg_integer(),
+              key :: non_neg_integer()
+            ) :: non_neg_integer()
+
+  @doc "Store a 256-bit value into a storage slot for the given contract address."
+  @callback storage_store(
+              state :: term(),
+              address :: non_neg_integer(),
+              key :: non_neg_integer(),
+              value :: non_neg_integer()
+            ) :: term()
+
+  # ---------------------------------------------------------------------------
+  # Constructor
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Wraps an implementation module and its initial state into a `%Database{}`.
+
+  ## Example
+
+      db = Database.new(Database.InMemory, Database.InMemory.init())
+  """
+  @spec new(module(), term()) :: t()
+  def new(impl, state) do
+    %__MODULE__{impl: impl, state: state}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Public API — dispatches to the implementation module
+  # ---------------------------------------------------------------------------
+
+  @spec get_account(t(), non_neg_integer()) :: account() | nil
+  def get_account(%__MODULE__{impl: impl, state: state}, address) do
+    impl.get_account(state, address)
+  end
+
+  @spec account_exists?(t(), non_neg_integer()) :: boolean()
+  def account_exists?(%__MODULE__{impl: impl, state: state}, address) do
+    impl.account_exists?(state, address)
+  end
+
+  @spec get_code(t(), non_neg_integer()) :: binary()
+  def get_code(%__MODULE__{impl: impl, state: state}, address) do
+    impl.get_code(state, address)
+  end
+
+  @spec get_balance(t(), non_neg_integer()) :: non_neg_integer()
+  def get_balance(%__MODULE__{impl: impl, state: state}, address) do
+    impl.get_balance(state, address)
+  end
+
+  @spec get_nonce(t(), non_neg_integer()) :: non_neg_integer()
+  def get_nonce(%__MODULE__{impl: impl, state: state}, address) do
+    impl.get_nonce(state, address)
+  end
+
+  @spec put_account(t(), non_neg_integer(), account()) :: t()
+  def put_account(%__MODULE__{impl: impl, state: state} = db, address, account) do
+    %{db | state: impl.put_account(state, address, account)}
+  end
+
+  @spec delete_account(t(), non_neg_integer()) :: t()
+  def delete_account(%__MODULE__{impl: impl, state: state} = db, address) do
+    %{db | state: impl.delete_account(state, address)}
+  end
+
+  @spec put_code(t(), non_neg_integer(), binary()) :: t()
+  def put_code(%__MODULE__{impl: impl, state: state} = db, address, code) do
+    %{db | state: impl.put_code(state, address, code)}
+  end
+
+  @spec set_balance(t(), non_neg_integer(), non_neg_integer()) :: t()
+  def set_balance(%__MODULE__{impl: impl, state: state} = db, address, balance) do
+    %{db | state: impl.set_balance(state, address, balance)}
+  end
+
+  @spec set_nonce(t(), non_neg_integer(), non_neg_integer()) :: t()
+  def set_nonce(%__MODULE__{impl: impl, state: state} = db, address, nonce) do
+    %{db | state: impl.set_nonce(state, address, nonce)}
+  end
+
+  @spec increment_nonce(t(), non_neg_integer()) :: t()
+  def increment_nonce(%__MODULE__{impl: impl, state: state} = db, address) do
+    %{db | state: impl.increment_nonce(state, address)}
+  end
+
+  @spec transfer(t(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
+          {:ok, t()} | {:error, :insufficient_balance}
+  def transfer(%__MODULE__{impl: impl, state: state} = db, from, to, amount) do
+    case impl.transfer(state, from, to, amount) do
+      {:ok, new_state} -> {:ok, %{db | state: new_state}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec storage_load(t(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  def storage_load(%__MODULE__{impl: impl, state: state}, address, key) do
+    impl.storage_load(state, address, key)
+  end
+
+  @spec storage_store(t(), non_neg_integer(), non_neg_integer(), non_neg_integer()) :: t()
+  def storage_store(%__MODULE__{impl: impl, state: state} = db, address, key, value) do
+    %{db | state: impl.storage_store(state, address, key, value)}
+  end
+end

--- a/lib/eevm/database/in_memory.ex
+++ b/lib/eevm/database/in_memory.ex
@@ -1,0 +1,208 @@
+defmodule EEVM.Database.InMemory do
+  @moduledoc """
+  In-memory database implementation using plain maps.
+
+  ## EVM Concepts
+
+  This is the default database backend for eevm. It stores all account state
+  (balances, nonces, code) and contract storage in Elixir maps — the same
+  data structures used by `EEVM.WorldState` and `EEVM.Storage` before the
+  Database abstraction was introduced.
+
+  The state is a map with two keys:
+
+  - `:accounts` — `%{address => account_map}` (balances, nonces, code)
+  - `:storage` — `%{address => %{slot => value}}` (per-contract storage)
+
+  This implementation is suitable for testing, single-transaction execution,
+  and learning. For production use with persistent state, implement the
+  `EEVM.Database` behaviour with a disk-backed store.
+
+  ## Elixir Learning Notes
+
+  - `@behaviour EEVM.Database` tells the compiler to verify that this module
+    implements all required callbacks. Missing callbacks produce warnings.
+  - The state is a plain map (not a struct) to keep it lightweight and
+    easy to inspect in tests.
+  """
+
+  @behaviour EEVM.Database
+
+  alias EEVM.Database
+
+  @type state :: %{
+          accounts: %{non_neg_integer() => Database.account()},
+          storage: %{non_neg_integer() => %{non_neg_integer() => non_neg_integer()}}
+        }
+
+  @doc """
+  Creates a new in-memory database state.
+
+  ## Options
+
+  - `:accounts` — initial account map (default: `%{}`)
+  - `:storage` — initial per-address storage map (default: `%{}`)
+
+  ## Examples
+
+      iex> state = EEVM.Database.InMemory.init()
+      iex> EEVM.Database.InMemory.get_balance(state, 0x1234)
+      0
+
+      iex> state = EEVM.Database.InMemory.init(accounts: %{1 => %{balance: 100}})
+      iex> EEVM.Database.InMemory.get_balance(state, 1)
+      100
+  """
+  @spec init(keyword()) :: state()
+  def init(opts \\ []) do
+    %{
+      accounts: Keyword.get(opts, :accounts, %{}),
+      storage: Keyword.get(opts, :storage, %{})
+    }
+  end
+
+  @doc """
+  Convenience: creates a fully wrapped `%Database{}` with InMemory backend.
+
+  This is the most common way to create a database for execution.
+
+  ## Examples
+
+      iex> db = EEVM.Database.InMemory.new()
+      iex> EEVM.Database.get_balance(db, 0x1234)
+      0
+  """
+  @spec new(keyword()) :: Database.t()
+  def new(opts \\ []) do
+    Database.new(__MODULE__, init(opts))
+  end
+
+  # ---------------------------------------------------------------------------
+  # Account reads
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def get_account(%{accounts: accounts}, address) do
+    Map.get(accounts, address)
+  end
+
+  @impl true
+  def account_exists?(%{accounts: accounts}, address) do
+    Map.has_key?(accounts, address)
+  end
+
+  @impl true
+  def get_code(state, address) do
+    case get_account(state, address) do
+      nil -> <<>>
+      account -> Map.get(account, :code, <<>>)
+    end
+  end
+
+  @impl true
+  def get_balance(state, address) do
+    case get_account(state, address) do
+      nil -> 0
+      account -> Map.get(account, :balance, 0)
+    end
+  end
+
+  @impl true
+  def get_nonce(state, address) do
+    case get_account(state, address) do
+      nil -> 0
+      account -> Map.get(account, :nonce, 0)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Account writes
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def put_account(%{accounts: accounts} = state, address, account) when is_map(account) do
+    %{state | accounts: Map.put(accounts, address, account)}
+  end
+
+  @impl true
+  def delete_account(%{accounts: accounts} = state, address) do
+    %{state | accounts: Map.delete(accounts, address)}
+  end
+
+  @impl true
+  def put_code(state, address, code) when is_binary(code) do
+    update_account(state, address, fn account -> Map.put(account, :code, code) end)
+  end
+
+  @impl true
+  def set_balance(state, address, balance) do
+    update_account(state, address, fn account -> Map.put(account, :balance, balance) end)
+  end
+
+  @impl true
+  def set_nonce(state, address, nonce) do
+    update_account(state, address, fn account -> Map.put(account, :nonce, nonce) end)
+  end
+
+  @impl true
+  def increment_nonce(state, address) do
+    update_account(state, address, fn account ->
+      Map.put(account, :nonce, Map.get(account, :nonce, 0) + 1)
+    end)
+  end
+
+  @impl true
+  def transfer(state, _from, _to, 0), do: {:ok, state}
+
+  def transfer(state, from, to, amount) do
+    from_balance = get_balance(state, from)
+
+    if from_balance < amount do
+      {:error, :insufficient_balance}
+    else
+      updated_state =
+        state
+        |> set_balance(from, from_balance - amount)
+        |> set_balance(to, get_balance(state, to) + amount)
+
+      {:ok, updated_state}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Storage
+  # ---------------------------------------------------------------------------
+
+  @impl true
+  def storage_load(%{storage: storage}, address, key) do
+    storage
+    |> Map.get(address, %{})
+    |> Map.get(key, 0)
+  end
+
+  @impl true
+  def storage_store(%{storage: storage} = state, address, key, value) do
+    address_storage = Map.get(storage, address, %{})
+    updated_slot = Map.put(address_storage, key, band_256(value))
+    %{state | storage: Map.put(storage, address, updated_slot)}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp update_account(state, address, updater) when is_function(updater, 1) do
+    existing =
+      case get_account(state, address) do
+        nil -> %{}
+        account -> account
+      end
+
+    put_account(state, address, updater.(existing))
+  end
+
+  defp band_256(value) do
+    import Bitwise
+    Bitwise.band(value, (1 <<< 256) - 1)
+  end
+end

--- a/lib/eevm/machine_state.ex
+++ b/lib/eevm/machine_state.ex
@@ -8,7 +8,7 @@ defmodule EEVM.MachineState do
   - **pc** (program counter): points to the current instruction
   - **stack**: the operand stack (max 1024 elements)
   - **memory**: byte-addressable linear memory
-  - **world_state**: account/code state used for external account lookups
+  - **db**: unified external state backend (accounts + contract storage)
   - **call_stack**: suspended parent frames during nested execution
   - **frame return metadata**: parent memory write-back offset and size
   - **is_static/depth**: execution mode and current call depth
@@ -25,7 +25,9 @@ defmodule EEVM.MachineState do
   - The `alias` keyword lets us reference modules by their short name.
   """
 
-  alias EEVM.{CallFrame, Memory, Stack, Storage, WorldState}
+  alias EEVM.{CallFrame, Memory, Stack}
+  alias EEVM.Database
+  alias EEVM.Database.InMemory, as: InMemoryDB
   alias EEVM.Context.{Block, Contract, Transaction}
 
   @type status :: :running | :stopped | :reverted | :invalid | :out_of_gas | {:error, atom()}
@@ -34,7 +36,7 @@ defmodule EEVM.MachineState do
           pc: non_neg_integer(),
           stack: Stack.t(),
           memory: Memory.t(),
-          storage: Storage.t(),
+          db: Database.t(),
           original_storage: %{non_neg_integer() => non_neg_integer()},
           transient_storage: %{non_neg_integer() => non_neg_integer()},
           tx: Transaction.t(),
@@ -43,7 +45,6 @@ defmodule EEVM.MachineState do
           accessed_addresses: MapSet.t(non_neg_integer()),
           accessed_storage_keys: MapSet.t({non_neg_integer(), non_neg_integer()}),
           created_addresses: MapSet.t(non_neg_integer()),
-          world_state: WorldState.t(),
           call_stack: [CallFrame.t()],
           frame_return_offset: non_neg_integer(),
           frame_return_size: non_neg_integer(),
@@ -61,7 +62,7 @@ defmodule EEVM.MachineState do
   defstruct pc: 0,
             stack: nil,
             memory: nil,
-            storage: nil,
+            db: nil,
             original_storage: %{},
             transient_storage: %{},
             tx: nil,
@@ -70,7 +71,6 @@ defmodule EEVM.MachineState do
             accessed_addresses: nil,
             accessed_storage_keys: nil,
             created_addresses: nil,
-            world_state: nil,
             call_stack: [],
             frame_return_offset: 0,
             frame_return_size: 0,
@@ -90,11 +90,12 @@ defmodule EEVM.MachineState do
     - `code` — the raw EVM bytecode as an Elixir binary
     - `opts` — optional keyword list:
       - `:gas` — initial gas (default: 1,000,000)
-      - `:storage` — initial storage (default: empty)
+      - `:db` — unified external database (default: empty in-memory DB)
+      - `:storage` — legacy initial storage (default: empty, backward-compat)
       - `:tx` — transaction context (default: empty)
       - `:block` — block context (default: empty)
       - `:contract` — contract/message context (default: empty)
-      - `:world_state` — external account state (default: empty)
+      - `:world_state` — legacy external account state (default: empty, backward-compat)
       - `:call_stack` — internal frame stack (default: `[]`)
       - `:frame_return_offset` — parent memory write-back offset (default: `0`)
       - `:frame_return_size` — parent memory write-back size (default: `0`)
@@ -117,7 +118,7 @@ defmodule EEVM.MachineState do
       code: code,
       stack: Stack.new(),
       memory: Memory.new(),
-      storage: Keyword.get(opts, :storage, Storage.new()),
+      db: init_db(opts, contract),
       original_storage: Keyword.get(opts, :original_storage, %{}),
       transient_storage: Keyword.get(opts, :transient_storage, %{}),
       tx: tx,
@@ -127,7 +128,6 @@ defmodule EEVM.MachineState do
         Keyword.get(opts, :accessed_addresses, pre_warm_addresses(contract, tx)),
       accessed_storage_keys: Keyword.get(opts, :accessed_storage_keys, MapSet.new()),
       created_addresses: Keyword.get(opts, :created_addresses, MapSet.new()),
-      world_state: Keyword.get(opts, :world_state, WorldState.new()),
       call_stack: Keyword.get(opts, :call_stack, []),
       frame_return_offset: Keyword.get(opts, :frame_return_offset, 0),
       frame_return_size: Keyword.get(opts, :frame_return_size, 0),
@@ -147,6 +147,28 @@ defmodule EEVM.MachineState do
     |> then(fn set ->
       Enum.reduce(0x01..0x0A, set, &MapSet.put(&2, &1))
     end)
+  end
+
+  defp init_db(opts, contract) do
+    case Keyword.fetch(opts, :db) do
+      {:ok, db} ->
+        db
+
+      :error ->
+        world_state = Keyword.get(opts, :world_state, EEVM.WorldState.new())
+        storage = Keyword.get(opts, :storage, EEVM.Storage.new())
+
+        InMemoryDB.new(
+          accounts: world_state.accounts,
+          storage: convert_storage(storage, contract.address)
+        )
+    end
+  end
+
+  defp convert_storage(%EEVM.Storage{slots: slots}, _address) when map_size(slots) == 0, do: %{}
+
+  defp convert_storage(%EEVM.Storage{slots: slots}, address) do
+    %{address => slots}
   end
 
   @doc "Returns the opcode byte at the current program counter, or nil if past end."

--- a/lib/eevm/opcodes/environment/external.ex
+++ b/lib/eevm/opcodes/environment/external.ex
@@ -10,7 +10,7 @@ defmodule EEVM.Opcodes.Environment.External do
   EXTCODEHASH (0x3F), and SELFBALANCE (0x47).
   """
 
-  alias EEVM.{MachineState, Memory, Stack, WorldState}
+  alias EEVM.{Database, MachineState, Memory, Stack}
   alias EEVM.Gas.Access
   alias EEVM.Gas.Dynamic
   alias EEVM.Gas.Memory, as: GasMemory
@@ -46,7 +46,7 @@ defmodule EEVM.Opcodes.Environment.External do
 
       case MachineState.consume_gas(state_after_access, access_cost) do
         {:ok, state_after_gas} ->
-          size = byte_size(WorldState.get_code(state_after_gas.world_state, addr))
+          size = byte_size(Database.get_code(state_after_gas.db, addr))
 
           case Stack.push(state_after_gas.stack, size) do
             {:ok, s2} -> {:ok, %{state_after_gas | stack: s2} |> MachineState.advance_pc()}
@@ -83,7 +83,7 @@ defmodule EEVM.Opcodes.Environment.External do
 
             case MachineState.consume_gas(state_after_access_gas, dynamic_cost) do
               {:ok, state_after_gas} ->
-                bytes = read_external_code(state_after_gas.world_state, addr, code_offset, length)
+                bytes = read_external_code(state_after_gas.db, addr, code_offset, length)
 
                 new_memory =
                   bytes
@@ -115,8 +115,8 @@ defmodule EEVM.Opcodes.Environment.External do
       case MachineState.consume_gas(state_after_access, access_cost) do
         {:ok, state_after_gas} ->
           hash_value =
-            if WorldState.account_exists?(state_after_gas.world_state, addr) do
-              code = WorldState.get_code(state_after_gas.world_state, addr)
+            if Database.account_exists?(state_after_gas.db, addr) do
+              code = Database.get_code(state_after_gas.db, addr)
               hash = ExKeccak.hash_256(code)
               <<hash_int::unsigned-big-256>> = hash
               hash_int
@@ -145,15 +145,15 @@ defmodule EEVM.Opcodes.Environment.External do
   def execute(_opcode, state), do: {:ok, MachineState.halt(state, :invalid)}
 
   defp lookup_balance(state, address) do
-    if WorldState.account_exists?(state.world_state, address) do
-      WorldState.get_balance(state.world_state, address)
+    if Database.account_exists?(state.db, address) do
+      Database.get_balance(state.db, address)
     else
       Contract.balance(state.contract, address)
     end
   end
 
-  defp read_external_code(world_state, address, offset, length) do
-    code = WorldState.get_code(world_state, address)
+  defp read_external_code(db, address, offset, length) do
+    code = Database.get_code(db, address)
     code_size = byte_size(code)
 
     if offset >= code_size do

--- a/lib/eevm/opcodes/stack_memory_storage/storage_ops.ex
+++ b/lib/eevm/opcodes/stack_memory_storage/storage_ops.ex
@@ -21,7 +21,7 @@ defmodule EEVM.Opcodes.StackMemoryStorage.StorageOps do
   - **TSTORE** (0x5D) — writes to transient storage. Costs 100 gas (warm access).
   """
 
-  alias EEVM.{MachineState, Stack, Storage}
+  alias EEVM.{Database, MachineState, Stack}
   alias EEVM.Gas.{Access, Dynamic}
 
   @cold_sload_cost 2100
@@ -37,7 +37,7 @@ defmodule EEVM.Opcodes.StackMemoryStorage.StorageOps do
 
       case MachineState.consume_gas(state_after_access, access_cost) do
         {:ok, state_after_gas} ->
-          value = Storage.load(state_after_gas.storage, key)
+          value = Database.storage_load(state_after_gas.db, contract_address, key)
 
           case Stack.push(state_after_gas.stack, value) do
             {:ok, s2} -> {:ok, %{state_after_gas | stack: s2} |> MachineState.advance_pc()}
@@ -73,7 +73,7 @@ defmodule EEVM.Opcodes.StackMemoryStorage.StorageOps do
 
       cold_cost = if is_warm, do: 0, else: @cold_sload_cost
       {original_value, state_with_original} = get_original_value(state_after_access, key)
-      current_value = Storage.load(state_with_original.storage, key)
+      current_value = Database.storage_load(state_with_original.db, contract_address, key)
 
       {sstore_gas, refund_delta} = Dynamic.sstore_cost(original_value, current_value, value)
       total_cost = cold_cost + sstore_gas
@@ -81,8 +81,8 @@ defmodule EEVM.Opcodes.StackMemoryStorage.StorageOps do
       case MachineState.consume_gas(state_with_original, total_cost) do
         {:ok, state_after_gas} ->
           state_after_refund = apply_refund_delta(state_after_gas, refund_delta)
-          new_storage = Storage.store(state_after_refund.storage, key, value)
-          {:ok, %{state_after_refund | storage: new_storage} |> MachineState.advance_pc()}
+          new_db = Database.storage_store(state_after_refund.db, contract_address, key, value)
+          {:ok, %{state_after_refund | db: new_db} |> MachineState.advance_pc()}
 
         {:error, :out_of_gas, halted} ->
           {:error, :out_of_gas, halted}
@@ -120,7 +120,7 @@ defmodule EEVM.Opcodes.StackMemoryStorage.StorageOps do
         {value, state}
 
       :error ->
-        value = Storage.load(state.storage, key)
+        value = Database.storage_load(state.db, state.contract.address, key)
         {value, %{state | original_storage: Map.put(state.original_storage, key, value)}}
     end
   end

--- a/lib/eevm/opcodes/system/calls.ex
+++ b/lib/eevm/opcodes/system/calls.ex
@@ -17,7 +17,7 @@ defmodule EEVM.Opcodes.System.Calls do
   All call opcodes use EIP-150 gas forwarding: `min(requested, available - available/64)`.
   """
 
-  alias EEVM.{Executor, MachineState, Memory, Stack, WorldState}
+  alias EEVM.{Database, Executor, MachineState, Memory, Stack}
   alias EEVM.Gas.Dynamic
   alias EEVM.Gas.Memory, as: GasMemory
   alias EEVM.Context.Contract
@@ -164,8 +164,8 @@ defmodule EEVM.Opcodes.System.Calls do
          ret_offset,
          ret_size
        ) do
-    world_state = state.world_state
-    account_exists = WorldState.account_exists?(world_state, address)
+    db = state.db
+    account_exists = Database.account_exists?(db, address)
 
     call_cost =
       Dynamic.call_value_cost(value) +
@@ -173,9 +173,9 @@ defmodule EEVM.Opcodes.System.Calls do
         call_memory_expansion_cost(state.memory, args_offset, args_size, ret_offset, ret_size)
 
     with {:ok, state_after_cost} <- MachineState.consume_gas(%{state | stack: stack}, call_cost),
-         {:ok, world_state_after_transfer} <-
-           WorldState.transfer(
-             state_after_cost.world_state,
+         {:ok, db_after_transfer} <-
+           Database.transfer(
+             state_after_cost.db,
              state_after_cost.contract.address,
              address,
              value
@@ -190,7 +190,7 @@ defmodule EEVM.Opcodes.System.Calls do
              forwarded_gas
            ) do
         {:ok, state_after_forward} ->
-          target_code = WorldState.get_code(world_state_after_transfer, address)
+          target_code = Database.get_code(db_after_transfer, address)
 
           if Precompiles.precompile?(address) and target_code == <<>> do
             child_gas = forwarded_gas + Dynamic.call_stipend(value)
@@ -235,11 +235,10 @@ defmodule EEVM.Opcodes.System.Calls do
             child_state =
               MachineState.new(target_code,
                 gas: child_gas,
-                storage: state_after_forward.storage,
+                db: db_after_transfer,
                 tx: state_after_forward.tx,
                 block: state_after_forward.block,
                 contract: child_contract,
-                world_state: world_state_after_transfer,
                 accessed_addresses: state_after_forward.accessed_addresses,
                 accessed_storage_keys: state_after_forward.accessed_storage_keys,
                 created_addresses: state_after_forward.created_addresses,
@@ -250,15 +249,10 @@ defmodule EEVM.Opcodes.System.Calls do
             child_result = Executor.run_loop(child_state)
             call_succeeded = child_result.status == :stopped
 
-            world_state_result =
+            db_result =
               if call_succeeded,
-                do: child_result.world_state,
-                else: state_after_forward.world_state
-
-            storage_result =
-              if call_succeeded,
-                do: child_result.storage,
-                else: state_after_forward.storage
+                do: child_result.db,
+                else: state_after_forward.db
 
             logs_result =
               if call_succeeded,
@@ -291,8 +285,7 @@ defmodule EEVM.Opcodes.System.Calls do
              |> Map.put(:stack, stack_after_call)
              |> Map.put(:memory, memory_result)
              |> Map.put(:return_data, child_result.return_data)
-             |> Map.put(:world_state, world_state_result)
-             |> Map.put(:storage, storage_result)
+             |> Map.put(:db, db_result)
              |> Map.put(:logs, logs_result)
              |> Map.put(:accessed_addresses, accessed_addresses_result)
              |> Map.put(:accessed_storage_keys, accessed_storage_keys_result)
@@ -345,7 +338,7 @@ defmodule EEVM.Opcodes.System.Calls do
           child_gas =
             forwarded_gas + if(add_stipend?, do: Dynamic.call_stipend(callvalue), else: 0)
 
-          target_code = WorldState.get_code(state_after_forward.world_state, address)
+          target_code = Database.get_code(state_after_forward.db, address)
 
           if Precompiles.precompile?(address) and target_code == <<>> do
             case Precompiles.execute(address, calldata, child_gas) do
@@ -386,11 +379,10 @@ defmodule EEVM.Opcodes.System.Calls do
             child_state =
               MachineState.new(target_code,
                 gas: child_gas,
-                storage: state_after_forward.storage,
+                db: state_after_forward.db,
                 tx: state_after_forward.tx,
                 block: state_after_forward.block,
                 contract: child_contract,
-                world_state: state_after_forward.world_state,
                 accessed_addresses: state_after_forward.accessed_addresses,
                 accessed_storage_keys: state_after_forward.accessed_storage_keys,
                 created_addresses: state_after_forward.created_addresses,
@@ -401,15 +393,10 @@ defmodule EEVM.Opcodes.System.Calls do
             child_result = Executor.run_loop(child_state)
             call_succeeded = child_result.status == :stopped
 
-            world_state_result =
+            db_result =
               if call_succeeded,
-                do: child_result.world_state,
-                else: state_after_forward.world_state
-
-            storage_result =
-              if call_succeeded,
-                do: child_result.storage,
-                else: state_after_forward.storage
+                do: child_result.db,
+                else: state_after_forward.db
 
             logs_result =
               if call_succeeded,
@@ -442,8 +429,7 @@ defmodule EEVM.Opcodes.System.Calls do
              |> Map.put(:stack, stack_after_call)
              |> Map.put(:memory, memory_result)
              |> Map.put(:return_data, child_result.return_data)
-             |> Map.put(:world_state, world_state_result)
-             |> Map.put(:storage, storage_result)
+             |> Map.put(:db, db_result)
              |> Map.put(:logs, logs_result)
              |> Map.put(:accessed_addresses, accessed_addresses_result)
              |> Map.put(:accessed_storage_keys, accessed_storage_keys_result)

--- a/lib/eevm/opcodes/system/creation.ex
+++ b/lib/eevm/opcodes/system/creation.ex
@@ -20,7 +20,7 @@ defmodule EEVM.Opcodes.System.Creation do
   @max_initcode_size 49_152
   @initcode_word_cost 2
 
-  alias EEVM.{Executor, MachineState, Memory, Stack, WorldState}
+  alias EEVM.{Database, Executor, MachineState, Memory, Stack}
   alias EEVM.Gas.Dynamic
   alias EEVM.Gas.Memory, as: GasMemory
   alias EEVM.Context.Contract
@@ -71,13 +71,13 @@ defmodule EEVM.Opcodes.System.Creation do
     case MachineState.consume_gas(%{state | stack: stack}, extra_cost) do
       {:ok, state_after_cost} ->
         creator = state_after_cost.contract.address
-        nonce = WorldState.get_nonce(state_after_cost.world_state, creator)
+        nonce = Database.get_nonce(state_after_cost.db, creator)
 
-        world_state_after_nonce =
-          WorldState.increment_nonce(state_after_cost.world_state, creator)
+        db_after_nonce =
+          Database.increment_nonce(state_after_cost.db, creator)
 
         if size > @max_initcode_size do
-          create_failed(%{state_after_cost | world_state: world_state_after_nonce}, stack)
+          create_failed(%{state_after_cost | db: db_after_nonce}, stack)
         else
           initcode_cost = @initcode_word_cost * div(size + 31, 32)
 
@@ -91,11 +91,11 @@ defmodule EEVM.Opcodes.System.Creation do
                   do: derive_create_address(creator, nonce),
                   else: derive_create2_address(creator, salt, init_code)
 
-              can_create = can_create_account?(world_state_after_nonce, new_address)
+              can_create = can_create_account?(db_after_nonce, new_address)
 
               if can_create do
-                case WorldState.transfer(world_state_after_nonce, creator, new_address, value) do
-                  {:ok, world_state_after_transfer} ->
+                case Database.transfer(db_after_nonce, creator, new_address, value) do
+                  {:ok, db_after_transfer} ->
                     child_contract =
                       Contract.new(
                         address: new_address,
@@ -108,11 +108,10 @@ defmodule EEVM.Opcodes.System.Creation do
                     child_state =
                       MachineState.new(init_code,
                         gas: state_after_initcode_cost.gas,
-                        storage: state_after_initcode_cost.storage,
+                        db: db_after_transfer,
                         tx: state_after_initcode_cost.tx,
                         block: state_after_initcode_cost.block,
                         contract: child_contract,
-                        world_state: world_state_after_transfer,
                         accessed_addresses: state_after_initcode_cost.accessed_addresses,
                         accessed_storage_keys: state_after_initcode_cost.accessed_storage_keys,
                         created_addresses: state_after_initcode_cost.created_addresses,
@@ -128,17 +127,17 @@ defmodule EEVM.Opcodes.System.Creation do
 
                       if byte_size(runtime_code) > @max_code_size do
                         create_failed(
-                          %{state_after_initcode_cost | world_state: world_state_after_nonce},
+                          %{state_after_initcode_cost | db: db_after_nonce},
                           stack
                         )
                       else
                         deposit_cost = Dynamic.code_deposit_cost(byte_size(runtime_code))
 
                         if child_result.gas >= deposit_cost do
-                          world_state_after_deploy =
-                            child_result.world_state
-                            |> WorldState.put_code(new_address, runtime_code)
-                            |> WorldState.set_nonce(new_address, 1)
+                          db_after_deploy =
+                            child_result.db
+                            |> Database.put_code(new_address, runtime_code)
+                            |> Database.set_nonce(new_address, 1)
 
                           {:ok, stack_after_create} = Stack.push(stack, new_address)
 
@@ -149,8 +148,7 @@ defmodule EEVM.Opcodes.System.Creation do
                            state_after_initcode_cost
                            |> Map.put(:stack, stack_after_create)
                            |> Map.put(:memory, memory_after_read)
-                           |> Map.put(:world_state, world_state_after_deploy)
-                           |> Map.put(:storage, child_result.storage)
+                           |> Map.put(:db, db_after_deploy)
                            |> Map.put(:logs, state_after_initcode_cost.logs ++ child_result.logs)
                            |> Map.put(:accessed_addresses, child_result.accessed_addresses)
                            |> Map.put(:accessed_storage_keys, child_result.accessed_storage_keys)
@@ -160,27 +158,27 @@ defmodule EEVM.Opcodes.System.Creation do
                            |> MachineState.advance_pc()}
                         else
                           create_failed(
-                            %{state_after_initcode_cost | world_state: world_state_after_nonce},
+                            %{state_after_initcode_cost | db: db_after_nonce},
                             stack
                           )
                         end
                       end
                     else
                       create_failed(
-                        %{state_after_initcode_cost | world_state: world_state_after_nonce},
+                        %{state_after_initcode_cost | db: db_after_nonce},
                         stack
                       )
                     end
 
                   {:error, :insufficient_balance} ->
                     create_failed(
-                      %{state_after_initcode_cost | world_state: world_state_after_nonce},
+                      %{state_after_initcode_cost | db: db_after_nonce},
                       stack
                     )
                 end
               else
                 create_failed(
-                  %{state_after_initcode_cost | world_state: world_state_after_nonce},
+                  %{state_after_initcode_cost | db: db_after_nonce},
                   stack
                 )
               end
@@ -195,16 +193,16 @@ defmodule EEVM.Opcodes.System.Creation do
     end
   end
 
-  defp can_create_account?(world_state, address) do
-    account = WorldState.get_account(world_state, address)
+  defp can_create_account?(db, address) do
+    account = Database.get_account(db, address)
 
     case account do
       nil ->
         true
 
       _ ->
-        WorldState.get_nonce(world_state, address) == 0 and
-          WorldState.get_code(world_state, address) == <<>>
+        Database.get_nonce(db, address) == 0 and
+          Database.get_code(db, address) == <<>>
     end
   end
 

--- a/lib/eevm/opcodes/system/termination.ex
+++ b/lib/eevm/opcodes/system/termination.ex
@@ -12,7 +12,7 @@ defmodule EEVM.Opcodes.System.Termination do
   created the contract.
   """
 
-  alias EEVM.{MachineState, Memory, Stack, WorldState}
+  alias EEVM.{Database, MachineState, Memory, Stack}
   alias EEVM.Gas.Memory, as: GasMemory
 
   @spec execute(non_neg_integer(), MachineState.t()) ::
@@ -58,9 +58,9 @@ defmodule EEVM.Opcodes.System.Termination do
   def execute(0xFF, state) do
     with {:ok, beneficiary, s1} <- Stack.pop(state.stack) do
       contract_address = state.contract.address
-      balance = WorldState.get_balance(state.world_state, contract_address)
+      balance = Database.get_balance(state.db, contract_address)
 
-      beneficiary_exists = WorldState.account_exists?(state.world_state, beneficiary)
+      beneficiary_exists = Database.account_exists?(state.db, beneficiary)
       dynamic_cost = if not beneficiary_exists and balance > 0, do: 25_000, else: 0
 
       case MachineState.consume_gas(%{state | stack: s1}, dynamic_cost) do
@@ -71,34 +71,34 @@ defmodule EEVM.Opcodes.System.Termination do
           created_this_tx =
             MapSet.member?(state_after_gas.created_addresses, contract_address)
 
-          world_state_after =
+          db_after =
             if created_this_tx do
               # EIP-6780: full deletion for contracts created in the same tx
-              ws = WorldState.delete_account(state_after_gas.world_state, contract_address)
+              db = Database.delete_account(state_after_gas.db, contract_address)
 
               if beneficiary != contract_address do
-                WorldState.set_balance(
-                  ws,
+                Database.set_balance(
+                  db,
                   beneficiary,
-                  WorldState.get_balance(ws, beneficiary) + balance
+                  Database.get_balance(db, beneficiary) + balance
                 )
               else
-                ws
+                db
               end
             else
               if beneficiary == contract_address do
-                state_after_gas.world_state
+                state_after_gas.db
               else
                 beneficiary_balance =
-                  WorldState.get_balance(state_after_gas.world_state, beneficiary)
+                  Database.get_balance(state_after_gas.db, beneficiary)
 
-                state_after_gas.world_state
-                |> WorldState.set_balance(contract_address, 0)
-                |> WorldState.set_balance(beneficiary, beneficiary_balance + balance)
+                state_after_gas.db
+                |> Database.set_balance(contract_address, 0)
+                |> Database.set_balance(beneficiary, beneficiary_balance + balance)
               end
             end
 
-          {:ok, MachineState.halt(%{state_after_gas | world_state: world_state_after}, :stopped)}
+          {:ok, MachineState.halt(%{state_after_gas | db: db_after}, :stopped)}
 
         {:error, :out_of_gas, halted_state} ->
           {:error, :out_of_gas, halted_state}

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule EEVM.MixProject do
         "compile --warnings-as-errors",
         "credo --strict",
         "dialyzer",
-        "test"
+        "cmd mix test"
       ]
     ]
   end

--- a/test/database_test.exs
+++ b/test/database_test.exs
@@ -1,0 +1,226 @@
+defmodule EEVM.DatabaseTest do
+  use ExUnit.Case, async: true
+
+  alias EEVM.Database
+  alias EEVM.Database.InMemory
+
+  describe "InMemory.new/1" do
+    test "creates empty database" do
+      db = InMemory.new()
+      assert %Database{impl: InMemory} = db
+    end
+
+    test "creates database with initial accounts" do
+      db = InMemory.new(accounts: %{1 => %{balance: 100, nonce: 5}})
+      assert Database.get_balance(db, 1) == 100
+      assert Database.get_nonce(db, 1) == 5
+    end
+
+    test "creates database with initial storage" do
+      db = InMemory.new(storage: %{0xAA => %{0 => 42, 1 => 99}})
+      assert Database.storage_load(db, 0xAA, 0) == 42
+      assert Database.storage_load(db, 0xAA, 1) == 99
+    end
+  end
+
+  describe "account reads" do
+    test "get_account returns nil for non-existent address" do
+      db = InMemory.new()
+      assert Database.get_account(db, 1) == nil
+    end
+
+    test "get_account returns account map" do
+      db = InMemory.new(accounts: %{1 => %{balance: 50, code: <<0xAA>>}})
+      assert Database.get_account(db, 1) == %{balance: 50, code: <<0xAA>>}
+    end
+
+    test "account_exists? returns false for missing accounts" do
+      db = InMemory.new()
+      refute Database.account_exists?(db, 1)
+    end
+
+    test "account_exists? returns true for existing accounts" do
+      db = InMemory.new(accounts: %{1 => %{}})
+      assert Database.account_exists?(db, 1)
+    end
+
+    test "get_code returns empty binary for non-existent account" do
+      db = InMemory.new()
+      assert Database.get_code(db, 1) == <<>>
+    end
+
+    test "get_code returns empty binary when account has no code" do
+      db = InMemory.new(accounts: %{1 => %{balance: 10}})
+      assert Database.get_code(db, 1) == <<>>
+    end
+
+    test "get_code returns code when present" do
+      db = InMemory.new(accounts: %{1 => %{code: <<0xFE, 0xFF>>}})
+      assert Database.get_code(db, 1) == <<0xFE, 0xFF>>
+    end
+
+    test "get_balance returns 0 for non-existent account" do
+      db = InMemory.new()
+      assert Database.get_balance(db, 1) == 0
+    end
+
+    test "get_balance returns balance when present" do
+      db = InMemory.new(accounts: %{1 => %{balance: 1_000}})
+      assert Database.get_balance(db, 1) == 1_000
+    end
+
+    test "get_nonce returns 0 for non-existent account" do
+      db = InMemory.new()
+      assert Database.get_nonce(db, 1) == 0
+    end
+
+    test "get_nonce returns nonce when present" do
+      db = InMemory.new(accounts: %{1 => %{nonce: 42}})
+      assert Database.get_nonce(db, 1) == 42
+    end
+  end
+
+  describe "account writes" do
+    test "put_account creates a new account" do
+      db = InMemory.new()
+      db = Database.put_account(db, 1, %{balance: 100})
+      assert Database.get_balance(db, 1) == 100
+    end
+
+    test "put_account replaces existing account" do
+      db = InMemory.new(accounts: %{1 => %{balance: 50}})
+      db = Database.put_account(db, 1, %{balance: 200, code: <<0xAA>>})
+      assert Database.get_balance(db, 1) == 200
+      assert Database.get_code(db, 1) == <<0xAA>>
+    end
+
+    test "delete_account removes account entirely" do
+      db = InMemory.new(accounts: %{1 => %{balance: 100, code: <<0xFF>>}})
+      db = Database.delete_account(db, 1)
+      refute Database.account_exists?(db, 1)
+      assert Database.get_account(db, 1) == nil
+    end
+
+    test "put_code sets code on existing account" do
+      db = InMemory.new(accounts: %{1 => %{balance: 50}})
+      db = Database.put_code(db, 1, <<0xAA, 0xBB>>)
+      assert Database.get_code(db, 1) == <<0xAA, 0xBB>>
+      assert Database.get_balance(db, 1) == 50
+    end
+
+    test "put_code creates account if non-existent" do
+      db = InMemory.new()
+      db = Database.put_code(db, 1, <<0xCC>>)
+      assert Database.get_code(db, 1) == <<0xCC>>
+    end
+
+    test "set_balance updates balance" do
+      db = InMemory.new(accounts: %{1 => %{balance: 50}})
+      db = Database.set_balance(db, 1, 200)
+      assert Database.get_balance(db, 1) == 200
+    end
+
+    test "set_balance creates account if non-existent" do
+      db = InMemory.new()
+      db = Database.set_balance(db, 1, 999)
+      assert Database.get_balance(db, 1) == 999
+    end
+
+    test "set_nonce updates nonce" do
+      db = InMemory.new(accounts: %{1 => %{nonce: 3}})
+      db = Database.set_nonce(db, 1, 10)
+      assert Database.get_nonce(db, 1) == 10
+    end
+
+    test "increment_nonce increments by 1" do
+      db = InMemory.new(accounts: %{1 => %{nonce: 5}})
+      db = Database.increment_nonce(db, 1)
+      assert Database.get_nonce(db, 1) == 6
+    end
+
+    test "increment_nonce starts from 0 for non-existent account" do
+      db = InMemory.new()
+      db = Database.increment_nonce(db, 1)
+      assert Database.get_nonce(db, 1) == 1
+    end
+  end
+
+  describe "transfer" do
+    test "transfers balance between accounts" do
+      db = InMemory.new(accounts: %{1 => %{balance: 100}, 2 => %{balance: 50}})
+      assert {:ok, db} = Database.transfer(db, 1, 2, 30)
+      assert Database.get_balance(db, 1) == 70
+      assert Database.get_balance(db, 2) == 80
+    end
+
+    test "transfer of 0 is a no-op" do
+      db = InMemory.new(accounts: %{1 => %{balance: 100}})
+      assert {:ok, ^db} = Database.transfer(db, 1, 2, 0)
+    end
+
+    test "transfer fails with insufficient balance" do
+      db = InMemory.new(accounts: %{1 => %{balance: 10}})
+      assert {:error, :insufficient_balance} = Database.transfer(db, 1, 2, 20)
+    end
+
+    test "transfer to non-existent account creates it" do
+      db = InMemory.new(accounts: %{1 => %{balance: 50}})
+      assert {:ok, db} = Database.transfer(db, 1, 2, 25)
+      assert Database.get_balance(db, 2) == 25
+    end
+  end
+
+  describe "storage" do
+    test "storage_load returns 0 for uninitialized slot" do
+      db = InMemory.new()
+      assert Database.storage_load(db, 0xAA, 0) == 0
+    end
+
+    test "storage_load returns stored value" do
+      db = InMemory.new(storage: %{0xAA => %{0 => 42}})
+      assert Database.storage_load(db, 0xAA, 0) == 42
+    end
+
+    test "storage_store writes value" do
+      db = InMemory.new()
+      db = Database.storage_store(db, 0xAA, 0, 42)
+      assert Database.storage_load(db, 0xAA, 0) == 42
+    end
+
+    test "storage_store masks to 256 bits" do
+      import Bitwise
+      db = InMemory.new()
+      big_val = 1 <<< 256
+      db = Database.storage_store(db, 0xAA, 0, big_val)
+      assert Database.storage_load(db, 0xAA, 0) == 0
+    end
+
+    test "storage is address-scoped" do
+      db = InMemory.new()
+      db = Database.storage_store(db, 0xAA, 0, 111)
+      db = Database.storage_store(db, 0xBB, 0, 222)
+      assert Database.storage_load(db, 0xAA, 0) == 111
+      assert Database.storage_load(db, 0xBB, 0) == 222
+    end
+
+    test "storage_store overwrites previous value" do
+      db = InMemory.new(storage: %{0xAA => %{0 => 10}})
+      db = Database.storage_store(db, 0xAA, 0, 99)
+      assert Database.storage_load(db, 0xAA, 0) == 99
+    end
+  end
+
+  describe "Database struct" do
+    test "returns %Database{} from all write operations" do
+      db = InMemory.new()
+      assert %Database{} = Database.put_account(db, 1, %{balance: 1})
+      assert %Database{} = Database.delete_account(db, 1)
+      assert %Database{} = Database.put_code(db, 1, <<>>)
+      assert %Database{} = Database.set_balance(db, 1, 0)
+      assert %Database{} = Database.set_nonce(db, 1, 0)
+      assert %Database{} = Database.increment_nonce(db, 1)
+      assert {:ok, %Database{}} = Database.transfer(db, 1, 2, 0)
+      assert %Database{} = Database.storage_store(db, 1, 0, 0)
+    end
+  end
+end

--- a/test/opcodes/selfdestruct_test.exs
+++ b/test/opcodes/selfdestruct_test.exs
@@ -1,7 +1,7 @@
 defmodule EEVM.Opcodes.SelfdestructTest do
   use ExUnit.Case, async: true
 
-  alias EEVM.WorldState
+  alias EEVM.{Database, WorldState}
   alias EEVM.Context.Contract
   alias EEVM.Gas.Static
 
@@ -19,8 +19,8 @@ defmodule EEVM.Opcodes.SelfdestructTest do
       result = EEVM.execute(code, world_state: world_state, contract: contract, gas: 1_000_000)
 
       assert result.status == :stopped
-      assert WorldState.get_balance(result.world_state, 0xAA) == 0
-      assert WorldState.get_balance(result.world_state, 0xBB) == 150
+      assert Database.get_balance(result.db, 0xAA) == 0
+      assert Database.get_balance(result.db, 0xBB) == 150
     end
 
     test "halts execution after SELFDESTRUCT" do
@@ -48,7 +48,7 @@ defmodule EEVM.Opcodes.SelfdestructTest do
       result = EEVM.execute(code, world_state: world_state, contract: contract, gas: 1_000_000)
 
       assert result.status == :stopped
-      assert WorldState.get_balance(result.world_state, 0xAA) == 100
+      assert Database.get_balance(result.db, 0xAA) == 100
     end
 
     test "zero balance self-destruct costs 5000 gas" do
@@ -78,7 +78,7 @@ defmodule EEVM.Opcodes.SelfdestructTest do
       assert result.status == :stopped
       expected_gas = 1_000_000 - Static.static_cost(0x60) - 5000 - 25_000
       assert result.gas == expected_gas
-      assert WorldState.get_balance(result.world_state, 0xCC) == 100
+      assert Database.get_balance(result.db, 0xCC) == 100
     end
 
     test "no extra gas for existing beneficiary with value" do
@@ -121,10 +121,10 @@ defmodule EEVM.Opcodes.SelfdestructTest do
       result = EEVM.execute(code, world_state: world_state, contract: contract, gas: 1_000_000)
 
       assert result.status == :stopped
-      assert WorldState.get_code(result.world_state, 0xAA) == <<0x60, 0x01>>
-      assert WorldState.get_nonce(result.world_state, 0xAA) == 5
-      assert WorldState.get_balance(result.world_state, 0xAA) == 0
-      assert WorldState.get_balance(result.world_state, 0xBB) == 50
+      assert Database.get_code(result.db, 0xAA) == <<0x60, 0x01>>
+      assert Database.get_nonce(result.db, 0xAA) == 5
+      assert Database.get_balance(result.db, 0xAA) == 0
+      assert Database.get_balance(result.db, 0xBB) == 50
     end
 
     test "EIP-6780: full deletion when contract was created in same tx" do
@@ -146,9 +146,9 @@ defmodule EEVM.Opcodes.SelfdestructTest do
         )
 
       assert result.status == :stopped
-      assert WorldState.get_account(result.world_state, 0xAA) == nil
-      assert WorldState.account_exists?(result.world_state, 0xAA) == false
-      assert WorldState.get_balance(result.world_state, 0xBB) == 150
+      assert Database.get_account(result.db, 0xAA) == nil
+      assert Database.account_exists?(result.db, 0xAA) == false
+      assert Database.get_balance(result.db, 0xBB) == 150
     end
 
     test "EIP-6780: full deletion to self when created in same tx burns balance" do
@@ -165,7 +165,7 @@ defmodule EEVM.Opcodes.SelfdestructTest do
         )
 
       assert result.status == :stopped
-      assert WorldState.get_account(result.world_state, 0xAA) == nil
+      assert Database.get_account(result.db, 0xAA) == nil
     end
 
     test "EIP-6780: not created this tx preserves account (only transfers balance)" do
@@ -181,11 +181,11 @@ defmodule EEVM.Opcodes.SelfdestructTest do
       result = EEVM.execute(code, world_state: world_state, contract: contract, gas: 1_000_000)
 
       assert result.status == :stopped
-      assert WorldState.account_exists?(result.world_state, 0xAA) == true
-      assert WorldState.get_code(result.world_state, 0xAA) == <<0xFE>>
-      assert WorldState.get_nonce(result.world_state, 0xAA) == 10
-      assert WorldState.get_balance(result.world_state, 0xAA) == 0
-      assert WorldState.get_balance(result.world_state, 0xCC) == 75
+      assert Database.account_exists?(result.db, 0xAA) == true
+      assert Database.get_code(result.db, 0xAA) == <<0xFE>>
+      assert Database.get_nonce(result.db, 0xAA) == 10
+      assert Database.get_balance(result.db, 0xAA) == 0
+      assert Database.get_balance(result.db, 0xCC) == 75
     end
   end
 end

--- a/test/opcodes/system_test.exs
+++ b/test/opcodes/system_test.exs
@@ -3,7 +3,7 @@ defmodule EEVM.Opcodes.SystemTest do
 
   import EEVM.TestSupport.BytecodeHelpers
 
-  alias EEVM.{Memory, Storage, WorldState}
+  alias EEVM.{Database, Memory, WorldState}
   alias EEVM.Context.Contract
 
   describe "Executor - Return & Halt" do
@@ -44,8 +44,8 @@ defmodule EEVM.Opcodes.SystemTest do
 
       assert result.status == :stopped
       assert created_address != 0
-      assert WorldState.get_code(result.world_state, created_address) == <<0xAA>>
-      assert WorldState.get_nonce(result.world_state, 0) == 1
+      assert Database.get_code(result.db, created_address) == <<0xAA>>
+      assert Database.get_nonce(result.db, 0) == 1
     end
 
     test "CREATE transfers value to created contract" do
@@ -55,8 +55,8 @@ defmodule EEVM.Opcodes.SystemTest do
       result = EEVM.execute(code, world_state: WorldState.new(%{0 => %{balance: 7}}))
       [created_address] = EEVM.stack_values(result)
 
-      assert WorldState.get_balance(result.world_state, 0) == 5
-      assert WorldState.get_balance(result.world_state, created_address) == 2
+      assert Database.get_balance(result.db, 0) == 5
+      assert Database.get_balance(result.db, created_address) == 2
     end
 
     test "CREATE2 with same salt and init code yields deterministic address" do
@@ -71,7 +71,7 @@ defmodule EEVM.Opcodes.SystemTest do
 
       assert address1 != 0
       assert address1 == address2
-      assert WorldState.get_code(result1.world_state, address1) == <<0xBB>>
+      assert Database.get_code(result1.db, address1) == <<0xBB>>
     end
 
     test "CREATE fails and pushes zero when balance is insufficient" do
@@ -82,7 +82,7 @@ defmodule EEVM.Opcodes.SystemTest do
 
       assert result.status == :stopped
       assert EEVM.stack_values(result) == [0]
-      assert WorldState.get_balance(result.world_state, 0) == 1
+      assert Database.get_balance(result.db, 0) == 1
     end
   end
 
@@ -120,8 +120,8 @@ defmodule EEVM.Opcodes.SystemTest do
 
       assert result.status == :stopped
       assert EEVM.stack_values(result) == [0]
-      assert WorldState.get_balance(result.world_state, 0) == 0
-      assert WorldState.get_balance(result.world_state, 1) == 0
+      assert Database.get_balance(result.db, 0) == 0
+      assert Database.get_balance(result.db, 1) == 0
     end
 
     test "transfers value on successful call" do
@@ -134,8 +134,8 @@ defmodule EEVM.Opcodes.SystemTest do
       result = EEVM.execute(code, world_state: world_state)
 
       assert EEVM.stack_values(result) == [1]
-      assert WorldState.get_balance(result.world_state, 0) == 6
-      assert WorldState.get_balance(result.world_state, 1) == 3
+      assert Database.get_balance(result.db, 0) == 6
+      assert Database.get_balance(result.db, 1) == 3
     end
 
     test "failed child call pushes 0 and restores balances" do
@@ -155,8 +155,8 @@ defmodule EEVM.Opcodes.SystemTest do
 
       assert result.status == :stopped
       assert EEVM.stack_values(result) == [0]
-      assert WorldState.get_balance(result.world_state, 0) == 8
-      assert WorldState.get_balance(result.world_state, 1) == 1
+      assert Database.get_balance(result.db, 0) == 8
+      assert Database.get_balance(result.db, 1) == 1
       assert result.return_data == <<>>
     end
   end
@@ -199,7 +199,7 @@ defmodule EEVM.Opcodes.SystemTest do
 
       assert result.status == :stopped
       assert EEVM.stack_values(result) == [0]
-      assert EEVM.Storage.load(result.storage, 0) == 0
+      assert Database.storage_load(result.db, 0, 0) == 0
     end
 
     test "pushes failure flag when child attempts LOG in static context" do
@@ -245,7 +245,7 @@ defmodule EEVM.Opcodes.SystemTest do
       assert result.return_data == <<0x00>>
       {mem, _} = Memory.read_bytes(result.memory, 0, 1)
       assert mem == <<0x00>>
-      assert EEVM.Storage.load(result.storage, 0) == 0
+      assert Database.storage_load(result.db, 0, 0) == 0
     end
 
     test "does not transfer value" do
@@ -258,8 +258,8 @@ defmodule EEVM.Opcodes.SystemTest do
 
       assert result.status == :stopped
       assert EEVM.stack_values(result) == [1]
-      assert WorldState.get_balance(result.world_state, 0) == 9
-      assert WorldState.get_balance(result.world_state, 1) == 0
+      assert Database.get_balance(result.db, 0) == 9
+      assert Database.get_balance(result.db, 1) == 0
     end
   end
 
@@ -280,8 +280,8 @@ defmodule EEVM.Opcodes.SystemTest do
       result = EEVM.execute(code, world_state: world_state, contract: contract)
 
       assert EEVM.stack_values(result) == [1]
-      assert Storage.load(result.storage, 0xAA) == 1
-      assert Storage.load(result.storage, 0x01) == 0
+      assert Database.storage_load(result.db, contract.address, 0xAA) == 1
+      assert Database.storage_load(result.db, contract.address, 0x01) == 0
     end
 
     test "preserves caller (msg.sender)" do
@@ -296,7 +296,7 @@ defmodule EEVM.Opcodes.SystemTest do
       result = EEVM.execute(code, world_state: world_state, contract: contract)
 
       assert EEVM.stack_values(result) == [1]
-      assert Storage.load(result.storage, 0) == 0xBEEF
+      assert Database.storage_load(result.db, contract.address, 0) == 0xBEEF
     end
 
     test "preserves callvalue (msg.value)" do
@@ -311,7 +311,7 @@ defmodule EEVM.Opcodes.SystemTest do
       result = EEVM.execute(code, world_state: world_state, contract: contract)
 
       assert EEVM.stack_values(result) == [1]
-      assert Storage.load(result.storage, 0) == 999
+      assert Database.storage_load(result.db, contract.address, 0) == 999
     end
 
     test "ADDRESS returns parent's address" do
@@ -326,7 +326,7 @@ defmodule EEVM.Opcodes.SystemTest do
       result = EEVM.execute(code, world_state: world_state, contract: contract)
 
       assert EEVM.stack_values(result) == [1]
-      assert Storage.load(result.storage, 0) == 0xAA
+      assert Database.storage_load(result.db, contract.address, 0) == 0xAA
     end
 
     test "pushes 0 on failure" do
@@ -357,8 +357,8 @@ defmodule EEVM.Opcodes.SystemTest do
       result = EEVM.execute(code, world_state: world_state, contract: contract)
 
       assert EEVM.stack_values(result) == [1]
-      assert Storage.load(result.storage, 0xAA) == 1
-      assert Storage.load(result.storage, 0x01) == 0
+      assert Database.storage_load(result.db, contract.address, 0xAA) == 1
+      assert Database.storage_load(result.db, contract.address, 0x01) == 0
     end
 
     test "CALLER returns current contract address" do
@@ -373,7 +373,7 @@ defmodule EEVM.Opcodes.SystemTest do
       result = EEVM.execute(code, world_state: world_state, contract: contract)
 
       assert EEVM.stack_values(result) == [1]
-      assert Storage.load(result.storage, 0) == 0xAAAA
+      assert Database.storage_load(result.db, contract.address, 0) == 0xAAAA
     end
 
     test "pushes 0 on failure" do

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -1,7 +1,7 @@
 defmodule EEVM.StorageTest do
   use ExUnit.Case, async: true
 
-  alias EEVM.Storage
+  alias EEVM.{Database, Storage}
 
   describe "Storage (SLOAD/SSTORE)" do
     test "SSTORE then SLOAD retrieves the stored value" do
@@ -91,7 +91,7 @@ defmodule EEVM.StorageTest do
       # Store 42 at slot 0
       code = <<0x60, 42, 0x60, 0, 0x55, 0x00>>
       result = EEVM.execute(code)
-      assert Storage.load(result.storage, 0) == 42
+      assert Database.storage_load(result.db, 0, 0) == 42
     end
   end
 end


### PR DESCRIPTION
## Summary

- Introduces `EEVM.Database` behaviour abstracting account state and contract storage behind a swappable backend interface (14 callbacks for account reads/writes + address-scoped storage)
- Adds `EEVM.Database.InMemory` default implementation using plain maps — drop-in replacement for the previous `WorldState` + `Storage` modules
- Migrates `MachineState` from separate `world_state`/`storage` fields to a unified `db` field, with backward-compatible conversion from legacy options
- Migrates all opcode modules (CALL, CREATE, SELFDESTRUCT, BALANCE, SLOAD/SSTORE, etc.) from direct `WorldState`/`Storage` usage to `Database` dispatch
- Fixes `mix quality` alias to run tests in the correct environment
- Adds 35 Database unit tests covering all callbacks and edge cases

## Design

```
%EEVM.Database{
  impl: EEVM.Database.InMemory,  # swappable backend module
  state: %{                       # opaque backend state
    accounts: %{addr => %{balance: _, nonce: _, code: _}},
    storage: %{addr => %{slot => value}}
  }
}
```

All public functions on `EEVM.Database` dispatch to the `impl` module, keeping opcode modules decoupled from any particular storage backend. Future backends (Merkle-backed, disk-backed, remote) implement `@behaviour EEVM.Database` and plug in via `Database.new(MyBackend, MyBackend.init())`.

## Files Changed

| File | Change |
|---|---|
| `lib/eevm/database.ex` | NEW — behaviour + dispatch wrapper |
| `lib/eevm/database/in_memory.ex` | NEW — default map-based implementation |
| `lib/eevm/machine_state.ex` | `world_state` + `storage` → `db` field |
| `lib/eevm/opcodes/system/calls.ex` | WorldState → Database |
| `lib/eevm/opcodes/system/creation.ex` | WorldState → Database |
| `lib/eevm/opcodes/system/termination.ex` | WorldState → Database |
| `lib/eevm/opcodes/environment/external.ex` | WorldState → Database |
| `lib/eevm/opcodes/stack_memory_storage/storage_ops.ex` | Storage → Database |
| `mix.exs` | Fix quality alias test env |
| `test/database_test.exs` | NEW — 35 tests |
| `test/opcodes/system_test.exs` | result.world_state → result.db |
| `test/opcodes/selfdestruct_test.exs` | result.world_state → result.db |
| `test/storage_test.exs` | result.storage → result.db |

## Verification

- `mix quality` passes: format ✓, compile (warnings-as-errors) ✓, credo --strict ✓, dialyzer ✓
- **387 tests, 0 failures** (352 existing + 35 new Database tests)