### PR TITLE
feat: Add transaction validation with intrinsic gas calculation

### DIFF
--- a/lib/eevm/context/transaction.ex
+++ b/lib/eevm/context/transaction.ex
@@ -34,12 +34,32 @@ defmodule EEVM.Context.Transaction do
   @type t :: %__MODULE__{
           origin: non_neg_integer(),
           gasprice: non_neg_integer(),
-          blob_hashes: [non_neg_integer()]
+          blob_hashes: [non_neg_integer()],
+          nonce: non_neg_integer(),
+          gas_limit: non_neg_integer(),
+          to: non_neg_integer() | nil,
+          value: non_neg_integer(),
+          data: binary(),
+          max_fee_per_gas: non_neg_integer(),
+          max_priority_fee_per_gas: non_neg_integer(),
+          access_list: [{non_neg_integer(), [non_neg_integer()]}],
+          max_fee_per_blob_gas: non_neg_integer(),
+          type: :legacy | :eip2930 | :eip1559 | :eip4844
         }
 
   defstruct origin: 0,
             gasprice: 0,
-            blob_hashes: []
+            blob_hashes: [],
+            nonce: 0,
+            gas_limit: 0,
+            to: nil,
+            value: 0,
+            data: <<>>,
+            max_fee_per_gas: 0,
+            max_priority_fee_per_gas: 0,
+            access_list: [],
+            max_fee_per_blob_gas: 0,
+            type: :legacy
 
   @doc "Creates a new transaction context with default values."
   @spec new() :: t()

--- a/lib/eevm/transaction/intrinsic_gas.ex
+++ b/lib/eevm/transaction/intrinsic_gas.ex
@@ -1,0 +1,56 @@
+defmodule EEVM.Transaction.IntrinsicGas do
+  @moduledoc """
+  Intrinsic transaction gas calculation.
+
+  ## EVM Concepts
+
+  Before EVM bytecode starts executing, every transaction pays an upfront
+  intrinsic gas cost. This covers the base transaction envelope plus static
+  costs derived from calldata, contract creation, and access-list entries.
+
+  This module implements the cost components needed by transaction validation.
+
+  ## Elixir Learning Notes
+
+  - `Enum.reduce/3` is used to accumulate byte and access-list costs.
+  - We compute `ceil(n / 32)` with integer arithmetic as `div(n + 31, 32)`.
+  """
+
+  alias EEVM.Context.Transaction
+
+  @tx_base_cost 21_000
+  @tx_data_zero_cost 4
+  @tx_data_non_zero_cost 16
+  @tx_create_cost 32_000
+  @initcode_word_cost 2
+  @access_list_address_cost 2_400
+  @access_list_storage_key_cost 1_900
+
+  @spec calculate(Transaction.t()) :: non_neg_integer()
+  def calculate(%Transaction{} = tx) do
+    @tx_base_cost +
+      calldata_cost(tx.data) +
+      creation_cost(tx) +
+      access_list_cost(tx.access_list)
+  end
+
+  defp calldata_cost(data) when is_binary(data) do
+    for <<byte <- data>>, reduce: 0 do
+      acc -> acc + if(byte == 0, do: @tx_data_zero_cost, else: @tx_data_non_zero_cost)
+    end
+  end
+
+  defp creation_cost(%Transaction{to: nil, data: initcode}) do
+    @tx_create_cost + @initcode_word_cost * word_count(initcode)
+  end
+
+  defp creation_cost(%Transaction{}), do: 0
+
+  defp word_count(data), do: div(byte_size(data) + 31, 32)
+
+  defp access_list_cost(access_list) do
+    Enum.reduce(access_list, 0, fn {_address, slot_keys}, acc ->
+      acc + @access_list_address_cost + @access_list_storage_key_cost * length(slot_keys)
+    end)
+  end
+end

--- a/lib/eevm/transaction/validator.ex
+++ b/lib/eevm/transaction/validator.ex
@@ -1,0 +1,130 @@
+defmodule EEVM.Transaction.Validator do
+  @moduledoc """
+  Transaction pre-execution validation.
+
+  ## EVM Concepts
+
+  Before running bytecode, Ethereum clients validate transaction envelope and
+  sender constraints against current state and block context. This module
+  performs those checks in deterministic order and returns the first failure.
+
+  ## Elixir Learning Notes
+
+  - Validation is modeled as a pipeline of `with` steps returning `:ok` or
+    `{:error, reason}`.
+  - Small private helpers keep each rule isolated and testable.
+  """
+
+  alias EEVM.Context.{Block, Transaction}
+  alias EEVM.Database
+  alias EEVM.Transaction.IntrinsicGas
+
+  @blob_gas_per_blob 131_072
+  @max_initcode_size 49_152
+
+  @spec validate(Transaction.t(), Database.t(), Block.t()) :: :ok | {:error, atom()}
+  def validate(%Transaction{} = tx, %Database{} = db, %Block{} = block) do
+    with :ok <- validate_intrinsic_gas(tx),
+         :ok <- validate_gas_limit_vs_block(tx, block),
+         :ok <- validate_nonce(tx, db),
+         :ok <- validate_eip1559_fees(tx, block),
+         :ok <- validate_balance(tx, db),
+         :ok <- validate_sender_is_eoa(tx, db),
+         :ok <- validate_blob_tx(tx, block) do
+      validate_initcode_size(tx)
+    end
+  end
+
+  defp validate_intrinsic_gas(%Transaction{} = tx) do
+    if tx.gas_limit >= IntrinsicGas.calculate(tx),
+      do: :ok,
+      else: {:error, :intrinsic_gas_too_low}
+  end
+
+  defp validate_gas_limit_vs_block(%Transaction{} = tx, %Block{} = block) do
+    if tx.gas_limit <= block.gaslimit,
+      do: :ok,
+      else: {:error, :gas_limit_exceeds_block}
+  end
+
+  defp validate_nonce(%Transaction{} = tx, %Database{} = db) do
+    account_nonce = Database.get_nonce(db, tx.origin)
+
+    cond do
+      account_nonce == tx.nonce -> :ok
+      account_nonce > tx.nonce -> {:error, :nonce_too_low}
+      true -> {:error, :nonce_too_high}
+    end
+  end
+
+  defp validate_eip1559_fees(%Transaction{type: type} = tx, %Block{} = block)
+       when type in [:eip1559, :eip4844] do
+    cond do
+      tx.max_fee_per_gas < tx.max_priority_fee_per_gas ->
+        {:error, :priority_fee_above_max_fee}
+
+      tx.max_fee_per_gas < block.basefee ->
+        {:error, :max_fee_below_basefee}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_eip1559_fees(%Transaction{}, %Block{}), do: :ok
+
+  defp validate_balance(%Transaction{} = tx, %Database{} = db) do
+    sender_balance = Database.get_balance(db, tx.origin)
+    required_balance = max_gas_cost(tx) + tx.value
+
+    if sender_balance >= required_balance,
+      do: :ok,
+      else: {:error, :insufficient_balance}
+  end
+
+  defp validate_sender_is_eoa(%Transaction{} = tx, %Database{} = db) do
+    if Database.get_code(db, tx.origin) == <<>>,
+      do: :ok,
+      else: {:error, :sender_not_eoa}
+  end
+
+  defp validate_blob_tx(%Transaction{type: :eip4844} = tx, %Block{} = block) do
+    cond do
+      tx.to == nil ->
+        {:error, :blob_tx_no_creation}
+
+      tx.blob_hashes == [] ->
+        {:error, :no_blob_data}
+
+      tx.max_fee_per_blob_gas < block.blob_base_fee ->
+        {:error, :blob_fee_too_low}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_blob_tx(%Transaction{}, %Block{}), do: :ok
+
+  defp validate_initcode_size(%Transaction{to: nil, data: data}) do
+    if byte_size(data) <= @max_initcode_size,
+      do: :ok,
+      else: {:error, :initcode_too_large}
+  end
+
+  defp validate_initcode_size(%Transaction{}), do: :ok
+
+  defp max_gas_cost(%Transaction{type: type} = tx) when type in [:eip1559, :eip4844] do
+    tx.gas_limit * tx.max_fee_per_gas + blob_gas_cost(tx)
+  end
+
+  defp max_gas_cost(%Transaction{} = tx) do
+    tx.gas_limit * tx.gasprice
+  end
+
+  defp blob_gas_cost(%Transaction{type: :eip4844} = tx) do
+    length(tx.blob_hashes) * @blob_gas_per_blob * tx.max_fee_per_blob_gas
+  end
+
+  defp blob_gas_cost(%Transaction{}), do: 0
+end

--- a/test/transaction/intrinsic_gas_test.exs
+++ b/test/transaction/intrinsic_gas_test.exs
@@ -1,0 +1,43 @@
+defmodule EEVM.Transaction.IntrinsicGasTest do
+  use ExUnit.Case, async: true
+
+  alias EEVM.Context.Transaction
+  alias EEVM.Transaction.IntrinsicGas
+
+  describe "calculate/1" do
+    test "plain call with empty calldata is base cost" do
+      tx = Transaction.new(to: 0xCAFE, data: <<>>)
+      assert IntrinsicGas.calculate(tx) == 21_000
+    end
+
+    test "plain call with mixed calldata charges zero and non-zero bytes" do
+      tx = Transaction.new(to: 0xCAFE, data: <<0x00, 0x01, 0x00, 0xFF>>)
+      assert IntrinsicGas.calculate(tx) == 21_000 + 4 + 16 + 4 + 16
+    end
+
+    test "contract creation includes create and initcode word costs" do
+      tx = Transaction.new(to: nil, data: <<1, 2, 3, 4, 5>>)
+      assert IntrinsicGas.calculate(tx) == 21_000 + 32_000 + 5 * 16 + 2
+    end
+
+    test "access list costs are included" do
+      tx =
+        Transaction.new(
+          to: 0xCAFE,
+          access_list: [
+            {0xAA, [1, 2]},
+            {0xBB, [3]}
+          ]
+        )
+
+      assert IntrinsicGas.calculate(tx) == 21_000 + 2 * 2_400 + 3 * 1_900
+    end
+
+    test "initcode word cost uses ceil(len/32)" do
+      tx = Transaction.new(to: nil, data: :binary.copy(<<1>>, 33))
+
+      assert IntrinsicGas.calculate(tx) ==
+               21_000 + 32_000 + 33 * 16 + 2 * 2
+    end
+  end
+end

--- a/test/transaction/validator_test.exs
+++ b/test/transaction/validator_test.exs
@@ -1,0 +1,181 @@
+defmodule EEVM.Transaction.ValidatorTest do
+  use ExUnit.Case, async: true
+
+  alias EEVM.Context.{Block, Transaction}
+  alias EEVM.Database.InMemory
+  alias EEVM.Transaction.Validator
+
+  @origin 0xA11CE
+
+  describe "validate/3" do
+    test "happy path passes for valid legacy transaction" do
+      tx = valid_tx(value: 10)
+      db = db_for_sender(balance: 1_000_000, nonce: 0, code: <<>>)
+      block = valid_block()
+
+      assert :ok = Validator.validate(tx, db, block)
+    end
+
+    test "returns intrinsic gas too low" do
+      tx = valid_tx(gas_limit: 20_999)
+
+      assert {:error, :intrinsic_gas_too_low} =
+               Validator.validate(tx, db_for_sender(), valid_block())
+    end
+
+    test "returns gas limit exceeds block" do
+      tx = valid_tx(gas_limit: 30_000)
+      block = valid_block(gaslimit: 29_999)
+
+      assert {:error, :gas_limit_exceeds_block} = Validator.validate(tx, db_for_sender(), block)
+    end
+
+    test "returns nonce too low" do
+      tx = valid_tx(nonce: 4)
+      db = db_for_sender(nonce: 5)
+
+      assert {:error, :nonce_too_low} = Validator.validate(tx, db, valid_block())
+    end
+
+    test "returns nonce too high" do
+      tx = valid_tx(nonce: 6)
+      db = db_for_sender(nonce: 5)
+
+      assert {:error, :nonce_too_high} = Validator.validate(tx, db, valid_block())
+    end
+
+    test "returns priority fee above max fee for eip1559" do
+      tx =
+        valid_tx(
+          type: :eip1559,
+          gasprice: 0,
+          max_priority_fee_per_gas: 101,
+          max_fee_per_gas: 100
+        )
+
+      assert {:error, :priority_fee_above_max_fee} =
+               Validator.validate(tx, db_for_sender(), valid_block(basefee: 10))
+    end
+
+    test "returns max fee below base fee for eip1559" do
+      tx =
+        valid_tx(
+          type: :eip1559,
+          gasprice: 0,
+          max_priority_fee_per_gas: 10,
+          max_fee_per_gas: 20
+        )
+
+      assert {:error, :max_fee_below_basefee} =
+               Validator.validate(tx, db_for_sender(), valid_block(basefee: 21))
+    end
+
+    test "returns insufficient balance" do
+      tx = valid_tx(gas_limit: 30_000, gasprice: 5, value: 100)
+      db = db_for_sender(balance: 100_000)
+
+      assert {:error, :insufficient_balance} = Validator.validate(tx, db, valid_block())
+    end
+
+    test "returns sender not eoa when sender has code" do
+      tx = valid_tx()
+      db = db_for_sender(code: <<0x60, 0x00>>)
+
+      assert {:error, :sender_not_eoa} = Validator.validate(tx, db, valid_block())
+    end
+
+    test "returns blob tx no creation when eip4844 tx targets creation" do
+      tx =
+        valid_tx(
+          type: :eip4844,
+          to: nil,
+          gas_limit: 60_000,
+          gasprice: 0,
+          max_fee_per_gas: 100,
+          max_priority_fee_per_gas: 2,
+          blob_hashes: [0x1234],
+          max_fee_per_blob_gas: 10
+        )
+
+      assert {:error, :blob_tx_no_creation} =
+               Validator.validate(tx, db_for_sender(balance: 10_000_000), valid_block(basefee: 1))
+    end
+
+    test "returns no blob data for eip4844 tx without blobs" do
+      tx =
+        valid_tx(
+          type: :eip4844,
+          gasprice: 0,
+          max_fee_per_gas: 100,
+          max_priority_fee_per_gas: 2,
+          blob_hashes: [],
+          max_fee_per_blob_gas: 10
+        )
+
+      assert {:error, :no_blob_data} =
+               Validator.validate(tx, db_for_sender(balance: 10_000_000), valid_block(basefee: 1))
+    end
+
+    test "returns blob fee too low for eip4844 tx" do
+      tx =
+        valid_tx(
+          type: :eip4844,
+          gasprice: 0,
+          max_fee_per_gas: 100,
+          max_priority_fee_per_gas: 2,
+          blob_hashes: [0x1234],
+          max_fee_per_blob_gas: 9
+        )
+
+      assert {:error, :blob_fee_too_low} =
+               Validator.validate(
+                 tx,
+                 db_for_sender(balance: 10_000_000),
+                 valid_block(basefee: 1, blob_base_fee: 10)
+               )
+    end
+
+    test "returns initcode too large for creation transaction" do
+      tx = valid_tx(to: nil, data: :binary.copy(<<1>>, 49_153), gas_limit: 900_000)
+
+      assert {:error, :initcode_too_large} =
+               Validator.validate(
+                 tx,
+                 db_for_sender(balance: 10_000_000),
+                 valid_block(gaslimit: 1_000_000)
+               )
+    end
+  end
+
+  defp valid_tx(overrides \\ []) do
+    Transaction.new(
+      [
+        origin: @origin,
+        nonce: 0,
+        gas_limit: 30_000,
+        to: 0xB0B,
+        value: 0,
+        data: <<>>,
+        gasprice: 1,
+        max_fee_per_gas: 0,
+        max_priority_fee_per_gas: 0,
+        access_list: [],
+        blob_hashes: [],
+        max_fee_per_blob_gas: 0,
+        type: :legacy
+      ] ++ overrides
+    )
+  end
+
+  defp db_for_sender(opts \\ []) do
+    balance = Keyword.get(opts, :balance, 1_000_000)
+    nonce = Keyword.get(opts, :nonce, 0)
+    code = Keyword.get(opts, :code, <<>>)
+
+    InMemory.new(accounts: %{@origin => %{balance: balance, nonce: nonce, code: code}})
+  end
+
+  defp valid_block(overrides \\ []) do
+    Block.new([gaslimit: 1_000_000, basefee: 0, blob_base_fee: 0] ++ overrides)
+  end
+end


### PR DESCRIPTION
## Summary

- Expands `EEVM.Context.Transaction` struct with fields needed for validation (nonce, gas_limit, to, value, data, type, and EIP-1559/4844 fee fields)
- Adds `EEVM.Transaction.IntrinsicGas` — calculates per EIP-2028 (calldata costs), EIP-3860 (initcode size), and EIP-2930 (access list costs)
- Adds `EEVM.Transaction.Validator` — `validate/3` enforces 8 rules: nonce match, gas limit floor/ceiling, sender balance, initcode size limit, max fee >= base fee, priority fee cap, blob transaction constraints

## Test Coverage

- 18 new tests covering intrinsic gas edge cases and all validator rules
- 405 total tests, 0 failures

## Changes

| File | Description |
|------|-------------|
| `lib/eevm/context/transaction.ex` | Extended struct with validation-relevant fields |
| `lib/eevm/transaction/intrinsic_gas.ex` | **New** — intrinsic gas calculation |
| `lib/eevm/transaction/validator.ex` | **New** — pre-execution validation pipeline |
| `test/transaction/intrinsic_gas_test.exs` | **New** — intrinsic gas tests |
| `test/transaction/validator_test.exs` | **New** — validator tests |