### PR TITLE
feat: Add 2048-bit logs bloom filter per Yellow Paper §4.3.1

### DIFF
--- a/lib/eevm.ex
+++ b/lib/eevm.ex
@@ -67,6 +67,12 @@ defmodule EEVM do
   @spec logs(MachineState.t()) :: [map()]
   def logs(%MachineState{} = state), do: state.logs
 
+  @doc "Computes the 256-byte logs bloom filter for the executed transaction."
+  @spec logs_bloom(MachineState.t()) :: EEVM.Bloom.t()
+  def logs_bloom(%MachineState{} = state) do
+    EEVM.Bloom.from_logs(state.logs)
+  end
+
   @doc """
   Disassembles bytecode into a human-readable list of instructions.
 

--- a/lib/eevm/bloom.ex
+++ b/lib/eevm/bloom.ex
@@ -1,0 +1,112 @@
+defmodule EEVM.Bloom do
+  @moduledoc """
+  Ethereum logs bloom filter — 2048-bit probabilistic filter for log indexing.
+
+  ## EVM Concepts
+
+  Transaction receipts include a 256-byte (2048-bit) bloom filter that summarizes
+  all logs emitted during execution. Light clients use bloom filters to quickly
+  skip blocks/transactions that definitely don't contain events of interest.
+
+  Each log's address and each indexed topic are added to the bloom using 3 hash
+  probes derived from Keccak-256. The algorithm is defined in Yellow Paper §4.3.1.
+
+  ## Elixir Learning Notes
+
+  - A bloom filter is represented as a fixed-size binary (`<<_::2048>>`).
+  - Bit-twiddling uses `Bitwise` operators (`band`, `bor`, `bsl`) on integers.
+  - We update a single byte inside a binary with pattern matching slices.
+  """
+
+  import Bitwise
+
+  @type log_entry :: %{address: non_neg_integer(), data: binary(), topics: [non_neg_integer()]}
+  @type t :: <<_::2048>>
+
+  @empty_bloom <<0::2048>>
+
+  @doc "Returns an empty (all-zero) 256-byte bloom filter."
+  @spec empty() :: t()
+  def empty, do: @empty_bloom
+
+  @doc """
+  Add an item (raw bytes) to the bloom filter.
+
+  The item should be a binary — 20 bytes for an address, 32 bytes for a topic.
+  """
+  @spec add(t(), binary()) :: t()
+  def add(bloom, item) when is_binary(bloom) and byte_size(bloom) == 256 and is_binary(item) do
+    <<b0, b1, b2, b3, b4, b5, _::binary>> = ExKeccak.hash_256(item)
+
+    bloom
+    |> set_bit(bit_position(b0, b1))
+    |> set_bit(bit_position(b2, b3))
+    |> set_bit(bit_position(b4, b5))
+  end
+
+  @doc """
+  Compute the bloom filter for a list of logs.
+
+  Each log's address and topics are added. The `data` field is NOT included.
+  """
+  @spec from_logs([log_entry()]) :: t()
+  def from_logs(logs) do
+    Enum.reduce(logs, empty(), fn %{address: address, topics: topics}, bloom ->
+      address_bytes = <<address::unsigned-big-160>>
+
+      bloom
+      |> add(address_bytes)
+      |> add_topics(topics)
+    end)
+  end
+
+  @doc "Check if a bloom filter might contain an item (false positives possible)."
+  @spec contains?(t(), binary()) :: boolean()
+  def contains?(bloom, item)
+      when is_binary(bloom) and byte_size(bloom) == 256 and is_binary(item) do
+    <<b0, b1, b2, b3, b4, b5, _::binary>> = ExKeccak.hash_256(item)
+
+    bit_set?(bloom, bit_position(b0, b1)) and
+      bit_set?(bloom, bit_position(b2, b3)) and
+      bit_set?(bloom, bit_position(b4, b5))
+  end
+
+  @doc "Bitwise OR of two bloom filters."
+  @spec merge(t(), t()) :: t()
+  def merge(left, right)
+      when is_binary(left) and byte_size(left) == 256 and is_binary(right) and
+             byte_size(right) == 256 do
+    left
+    |> :binary.bin_to_list()
+    |> Enum.zip(:binary.bin_to_list(right))
+    |> Enum.map(fn {a, b} -> bor(a, b) end)
+    |> :binary.list_to_bin()
+  end
+
+  defp add_topics(bloom, topics) do
+    Enum.reduce(topics, bloom, fn topic, acc ->
+      topic_bytes = <<topic::unsigned-big-256>>
+      add(acc, topic_bytes)
+    end)
+  end
+
+  defp bit_position(hi, lo), do: band(hi * 256 + lo, 0x07FF)
+
+  defp set_bit(bloom, bit_pos) do
+    bit_index = 0x07FF - bit_pos
+    byte_index = div(bit_index, 8)
+    bit_value = bsl(1, 7 - rem(bit_index, 8))
+
+    <<pre::binary-size(byte_index), byte, post::binary>> = bloom
+    <<pre::binary, bor(byte, bit_value), post::binary>>
+  end
+
+  defp bit_set?(bloom, bit_pos) do
+    bit_index = 0x07FF - bit_pos
+    byte_index = div(bit_index, 8)
+    bit_value = bsl(1, 7 - rem(bit_index, 8))
+
+    <<_::binary-size(byte_index), byte, _::binary>> = bloom
+    band(byte, bit_value) == bit_value
+  end
+end

--- a/test/bloom_test.exs
+++ b/test/bloom_test.exs
@@ -1,0 +1,131 @@
+defmodule EEVM.BloomTest do
+  use ExUnit.Case, async: true
+
+  alias EEVM.Bloom
+  alias EEVM.Context.Contract
+
+  describe "empty bloom" do
+    test "empty/0 returns 256 zero bytes" do
+      assert Bloom.empty() == <<0::2048>>
+      assert byte_size(Bloom.empty()) == 256
+    end
+
+    test "from_logs/1 with no logs returns empty bloom" do
+      assert Bloom.from_logs([]) == Bloom.empty()
+    end
+  end
+
+  describe "single item insertion" do
+    test "address sets deterministic bloom bytes" do
+      address = <<1::unsigned-big-160>>
+      bloom = Bloom.add(Bloom.empty(), address)
+
+      assert byte_at(bloom, 57) == 0x02
+      assert byte_at(bloom, 114) == 0x01
+      assert byte_at(bloom, 239) == 0x01
+    end
+
+    test "topic sets deterministic bloom bytes" do
+      topic = <<1::unsigned-big-256>>
+      bloom = Bloom.add(Bloom.empty(), topic)
+
+      assert byte_at(bloom, 61) == 0x04
+      assert byte_at(bloom, 85) == 0x04
+      assert byte_at(bloom, 222) == 0x40
+    end
+  end
+
+  describe "from_logs/1 integration" do
+    test "single log with address and topics sets all probes" do
+      log = %{address: 0xCAFE, topics: [0x01, 0x02], data: <<0xAA, 0xBB>>}
+      bloom = Bloom.from_logs([log])
+
+      assert Bloom.contains?(bloom, <<0xCAFE::unsigned-big-160>>)
+      assert Bloom.contains?(bloom, <<1::unsigned-big-256>>)
+      assert Bloom.contains?(bloom, <<2::unsigned-big-256>>)
+    end
+
+    test "multiple logs accumulate address and topic probes" do
+      logs = [
+        %{address: 0x1111, topics: [0xAAA], data: <<>>},
+        %{address: 0x2222, topics: [0xBBB, 0xCCC], data: <<0x01>>}
+      ]
+
+      bloom = Bloom.from_logs(logs)
+
+      assert Bloom.contains?(bloom, <<0x1111::unsigned-big-160>>)
+      assert Bloom.contains?(bloom, <<0x2222::unsigned-big-160>>)
+      assert Bloom.contains?(bloom, <<0xAAA::unsigned-big-256>>)
+      assert Bloom.contains?(bloom, <<0xBBB::unsigned-big-256>>)
+      assert Bloom.contains?(bloom, <<0xCCC::unsigned-big-256>>)
+    end
+  end
+
+  describe "contains?/2" do
+    test "returns true for inserted item" do
+      item = <<0x1234::unsigned-big-256>>
+      bloom = Bloom.add(Bloom.empty(), item)
+
+      assert Bloom.contains?(bloom, item)
+    end
+
+    test "returns false for item not inserted (high probability)" do
+      inserted = <<0x1234::unsigned-big-256>>
+      missing = <<0xDEAD_BEEF::unsigned-big-256>>
+      bloom = Bloom.add(Bloom.empty(), inserted)
+
+      refute Bloom.contains?(bloom, missing)
+    end
+  end
+
+  describe "merge/2" do
+    test "merged bloom contains items from both inputs" do
+      left_item = <<0x1111::unsigned-big-256>>
+      right_item = <<0x2222::unsigned-big-256>>
+
+      left = Bloom.add(Bloom.empty(), left_item)
+      right = Bloom.add(Bloom.empty(), right_item)
+      merged = Bloom.merge(left, right)
+
+      assert Bloom.contains?(merged, left_item)
+      assert Bloom.contains?(merged, right_item)
+    end
+  end
+
+  describe "known vector" do
+    test "from_logs/1 matches expected 256-byte bloom" do
+      log = %{
+        address: 0x0000000000000000000000000000000000000001,
+        topics: [0x0000000000000000000000000000000000000000000000000000000000000001],
+        data: <<>>
+      }
+
+      expected =
+        Base.decode16!(
+          "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000040000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000100000000000000000000000000000000",
+          case: :lower
+        )
+
+      assert Bloom.from_logs([log]) == expected
+    end
+  end
+
+  describe "EEVM logs_bloom/1 integration" do
+    test "LOG1 execution produces non-empty bloom" do
+      code = <<0x60, 0x2A, 0x60, 0x00, 0x60, 0x00, 0xA1, 0x00>>
+      result = EEVM.execute(code, contract: Contract.new(address: 0xABCD))
+
+      assert EEVM.logs(result) != []
+      refute EEVM.logs_bloom(result) == Bloom.empty()
+    end
+
+    test "execution with no logs produces empty bloom" do
+      result = EEVM.execute(<<0x00>>)
+
+      assert EEVM.logs(result) == []
+      assert EEVM.logs_bloom(result) == Bloom.empty()
+    end
+  end
+
+  defp byte_at(binary, index), do: :binary.at(binary, index)
+end


### PR DESCRIPTION
## Summary

- Adds `EEVM.Bloom` — 2048-bit (256-byte) bloom filter implementing the Yellow Paper §4.3.1 algorithm using keccak256 hashing with 3 bit positions per topic/address
- Adds `EEVM.logs_bloom/1` public accessor on the main `EEVM` module for lazy bloom computation from execution results
- Supports adding individual items, building from log entries, and membership testing

## Test Coverage

- 12 new tests including unit tests for bit manipulation, log entry integration, and end-to-end `EEVM.execute` + bloom verification
- 399 total tests, 0 failures

## Changes

| File | Description |
|------|-------------|
| `lib/eevm/bloom.ex` | **New** — bloom filter implementation |
| `lib/eevm.ex` | Added `logs_bloom/1` public accessor |
| `test/bloom_test.exs` | **New** — bloom filter tests |