### PR TITLE
docs: add @moduledoc to all undocumented modules

### DIFF
--- a/lib/eevm/precompiles/bn256_add.ex
+++ b/lib/eevm/precompiles/bn256_add.ex
@@ -1,5 +1,5 @@
 defmodule EEVM.Precompiles.BN256Add do
-  @moduledoc false
+  @moduledoc "Precompile 0x06 — BN256 point addition. Delegates to `BN256.execute_add/2`."
   @behaviour EEVM.Precompile
 
   alias EEVM.Precompiles.BN256

--- a/lib/eevm/precompiles/bn256_mul.ex
+++ b/lib/eevm/precompiles/bn256_mul.ex
@@ -1,5 +1,5 @@
 defmodule EEVM.Precompiles.BN256Mul do
-  @moduledoc false
+  @moduledoc "Precompile 0x07 — BN256 scalar multiplication. Delegates to `BN256.execute_mul/2`."
   @behaviour EEVM.Precompile
 
   alias EEVM.Precompiles.BN256

--- a/lib/eevm/precompiles/bn256_pairing.ex
+++ b/lib/eevm/precompiles/bn256_pairing.ex
@@ -1,5 +1,5 @@
 defmodule EEVM.Precompiles.BN256Pairing do
-  @moduledoc false
+  @moduledoc "Precompile 0x08 — BN256 pairing check. Delegates to `BN256.execute_pairing/2`."
   @behaviour EEVM.Precompile
 
   alias EEVM.Precompiles.BN256

--- a/test/support/bytecode_helpers.ex
+++ b/test/support/bytecode_helpers.ex
@@ -1,5 +1,5 @@
 defmodule EEVM.TestSupport.BytecodeHelpers do
-  @moduledoc false
+  @moduledoc "Helpers for building raw EVM bytecode programs in tests (CREATE/CREATE2 init-code writers)."
 
   @spec build_create_program(binary(), :create, non_neg_integer()) :: binary()
   def build_create_program(init_code, :create, value) do

--- a/test/support/state_test_catalog.ex
+++ b/test/support/state_test_catalog.ex
@@ -1,4 +1,6 @@
 defmodule EEVM.TestSupport.StateTestCatalog do
+  @moduledoc "Discovers StateTest JSON fixtures on disk and filters them against the skip list."
+
   @default_glob "test/fixtures/state_tests/smoke/*.json"
   @official_glob "test/fixtures/state_tests/ethereum-tests/GeneralStateTests/**/*.json"
   @default_skip_file "test/fixtures/state_tests/skip.txt"

--- a/test/support/state_test_fixture.ex
+++ b/test/support/state_test_fixture.ex
@@ -1,4 +1,6 @@
 defmodule EEVM.TestSupport.StateTestFixture do
+  @moduledoc "Parses official StateTest JSON fixtures into typed structs for the test runner."
+
   alias EEVM.Context.{Block, Transaction}
 
   @empty_logs_hash "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"

--- a/test/support/state_test_runner.ex
+++ b/test/support/state_test_runner.ex
@@ -1,4 +1,6 @@
 defmodule EEVM.TestSupport.StateTestRunner do
+  @moduledoc "Executes a single StateTest case and validates the post-state root and logs hash."
+
   alias EEVM.{Config, Database, StateRoot}
   alias EEVM.Context.Contract
   alias EEVM.Database.InMemory


### PR DESCRIPTION
## Summary

- Adds `@moduledoc` to the 3 BN256 precompile wrappers (`bn256_add.ex`, `bn256_mul.ex`, `bn256_pairing.ex`) that previously had `@moduledoc false`
- Adds `@moduledoc` to all 4 test support modules (`BytecodeHelpers`, `StateTestCatalog`, `StateTestFixture`, `StateTestRunner`)
- Every module in the project now has documentation — 60/60 lib files + 4/4 test support files

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test` — 511 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)