### PR TITLE
Implement set-code transactions (EIP-7702)

### DIFF
--- a/lib/eevm/context/transaction.ex
+++ b/lib/eevm/context/transaction.ex
@@ -43,8 +43,18 @@ defmodule EEVM.Context.Transaction do
           max_fee_per_gas: non_neg_integer(),
           max_priority_fee_per_gas: non_neg_integer(),
           access_list: [{non_neg_integer(), [non_neg_integer()]}],
+          authorization_list: [authorization()],
           max_fee_per_blob_gas: non_neg_integer(),
-          type: :legacy | :eip2930 | :eip1559 | :eip4844
+          type: :legacy | :eip2930 | :eip1559 | :eip4844 | :eip7702
+        }
+
+  @type authorization :: %{
+          required(:chain_id) => non_neg_integer(),
+          required(:address) => non_neg_integer(),
+          required(:nonce) => non_neg_integer(),
+          required(:y_parity) => 0 | 1,
+          required(:r) => non_neg_integer(),
+          required(:s) => non_neg_integer()
         }
 
   defstruct origin: 0,
@@ -58,6 +68,7 @@ defmodule EEVM.Context.Transaction do
             max_fee_per_gas: 0,
             max_priority_fee_per_gas: 0,
             access_list: [],
+            authorization_list: [],
             max_fee_per_blob_gas: 0,
             type: :legacy
 

--- a/lib/eevm/transaction.ex
+++ b/lib/eevm/transaction.ex
@@ -16,6 +16,24 @@ defmodule EEVM.Transaction do
           | EEVM.Transaction.AccessList.t()
           | EEVM.Transaction.FeeMarket.t()
           | EEVM.Transaction.Blob.t()
+          | EEVM.Transaction.SetCode.t()
+
+  @type authorization_tuple :: EEVM.Transaction.Authorization.t()
+
+  defmodule Authorization do
+    @moduledoc "EIP-7702 authorization tuple."
+
+    @type t :: %__MODULE__{
+            chain_id: non_neg_integer(),
+            address: EEVM.Transaction.address(),
+            nonce: non_neg_integer(),
+            y_parity: 0 | 1,
+            r: non_neg_integer(),
+            s: non_neg_integer()
+          }
+
+    defstruct [:chain_id, :address, :nonce, :y_parity, :r, :s]
+  end
 
   defmodule Legacy do
     @moduledoc "Legacy transaction (type 0)."
@@ -133,6 +151,42 @@ defmodule EEVM.Transaction do
       :access_list,
       :max_fee_per_blob_gas,
       :blob_versioned_hashes,
+      :y_parity,
+      :r,
+      :s
+    ]
+  end
+
+  defmodule SetCode do
+    @moduledoc "EIP-7702 set-code transaction (type 4)."
+
+    @type t :: %__MODULE__{
+            chain_id: non_neg_integer(),
+            nonce: non_neg_integer(),
+            max_priority_fee_per_gas: non_neg_integer(),
+            max_fee_per_gas: non_neg_integer(),
+            gas_limit: non_neg_integer(),
+            to: EEVM.Transaction.address(),
+            value: non_neg_integer(),
+            data: binary(),
+            access_list: EEVM.Transaction.access_list(),
+            authorization_list: [EEVM.Transaction.authorization_tuple()],
+            y_parity: 0 | 1,
+            r: non_neg_integer(),
+            s: non_neg_integer()
+          }
+
+    defstruct [
+      :chain_id,
+      :nonce,
+      :max_priority_fee_per_gas,
+      :max_fee_per_gas,
+      :gas_limit,
+      :to,
+      :value,
+      :data,
+      :access_list,
+      :authorization_list,
       :y_parity,
       :r,
       :s


### PR DESCRIPTION
## Summary
- add Prague-gated type `0x04` set-code transactions with envelope, signing, validation, and intrinsic gas support
- process authorization tuples to install delegation indicators and support one-hop delegated CALL-family execution
- preserve raw delegation bytes for EXTCODE introspection and cover the new behavior with transaction and opcode tests

## Validation
- mix format --check-formatted
- mix compile --warnings-as-errors
- mix credo --strict
- mix test

Closes #80