### PR TITLE
feat(tracer): opt-in opcode-level execution tracing (EIP-3155)

### DIFF
--- a/lib/eevm.ex
+++ b/lib/eevm.ex
@@ -34,7 +34,7 @@ defmodule EEVM do
   - **Typespecs** — `@spec` annotations for documentation and Dialyzer
   """
 
-  alias EEVM.{Executor, MachineState, Stack}
+  alias EEVM.{Executor, MachineState, Stack, Tracer}
 
   @doc """
   Executes EVM bytecode and returns the final machine state.
@@ -51,6 +51,28 @@ defmodule EEVM do
   @spec execute(binary(), keyword()) :: EEVM.MachineState.t()
   def execute(bytecode, opts \\ []) do
     Executor.run(bytecode, opts)
+  end
+
+  @doc """
+  Executes bytecode with an opcode-level tracer attached.
+
+  Returns `{final_state, tracer}`. The tracer holds one `TraceStep` per
+  executed opcode (see `EEVM.Tracer`). Use `EEVM.Tracer.to_json/1` to emit
+  a trace in EIP-3155 / geth `--json` format.
+
+  ## Example
+
+      iex> {state, tracer} = EEVM.trace(<<0x60, 0x01, 0x60, 0x02, 0x01, 0x00>>)
+      iex> state.status
+      :stopped
+      iex> length(EEVM.Tracer.steps(tracer))
+      4
+  """
+  @spec trace(binary(), keyword()) :: {MachineState.t(), Tracer.t()}
+  def trace(bytecode, opts \\ []) do
+    opts_with_tracer = Keyword.put(opts, :tracer, Tracer.new())
+    state = Executor.run(bytecode, opts_with_tracer)
+    {state, state.tracer}
   end
 
   @doc """

--- a/lib/eevm/executor.ex
+++ b/lib/eevm/executor.ex
@@ -32,12 +32,11 @@ defmodule EEVM.Executor do
     their semantics.
   """
 
-  alias EEVM.{HardforkConfig, MachineState}
+  alias EEVM.{HardforkConfig, MachineState, Memory, Stack, Tracer}
   alias EEVM.Database
   alias EEVM.Gas.Static
   alias EEVM.Transaction.IntrinsicGas
-  alias EEVM.Database
-  alias EEVM.Gas.Static
+  alias EEVM.Tracer.TraceStep
 
   alias EEVM.Opcodes.{
     Arithmetic,
@@ -109,17 +108,25 @@ defmodule EEVM.Executor do
 
       opcode ->
         static_cost = if opcode == 0xFE, do: state.gas, else: Static.static_cost(opcode)
+        traced_state = trace_opcode(state, opcode, static_cost)
 
-        case MachineState.consume_gas(state, static_cost) do
+        case MachineState.consume_gas(traced_state, static_cost) do
           {:ok, state_after_gas} ->
             case execute_opcode(opcode, state_after_gas) do
-              {:ok, new_state} -> run_loop(new_state)
-              {:error, :out_of_gas, halted_state} -> halted_state
-              {:error, reason, error_state} -> MachineState.halt(error_state, {:error, reason})
+              {:ok, new_state} ->
+                run_loop(new_state)
+
+              {:error, :out_of_gas, halted_state} ->
+                annotate_last_error(halted_state, :out_of_gas)
+
+              {:error, reason, error_state} ->
+                error_state
+                |> MachineState.halt({:error, reason})
+                |> annotate_last_error(reason)
             end
 
           {:error, :out_of_gas, halted_state} ->
-            halted_state
+            annotate_last_error(halted_state, :out_of_gas)
         end
     end
   end
@@ -248,4 +255,33 @@ defmodule EEVM.Executor do
     do: Termination.execute(op, state)
 
   defp execute_opcode(_op, state), do: {:ok, MachineState.halt(state, :invalid)}
+
+  # Trace bookkeeping is a no-op when no tracer is attached — one pattern match,
+  # one return. All helpers below keep this fast path.
+
+  defp trace_opcode(%MachineState{tracer: nil} = state, _opcode, _static_cost), do: state
+
+  defp trace_opcode(%MachineState{tracer: tracer} = state, opcode, static_cost) do
+    step = %TraceStep{
+      pc: state.pc,
+      op: Tracer.op_name(opcode),
+      op_byte: opcode,
+      gas_remaining: state.gas,
+      gas_cost: static_cost,
+      stack: Stack.to_list(state.stack),
+      memory_size: Memory.size(state.memory),
+      depth: state.depth,
+      refund: state.refund,
+      return_data: state.return_data,
+      error: nil
+    }
+
+    %{state | tracer: Tracer.record(tracer, step)}
+  end
+
+  defp annotate_last_error(%MachineState{tracer: nil} = state, _reason), do: state
+
+  defp annotate_last_error(%MachineState{tracer: tracer} = state, reason) do
+    %{state | tracer: Tracer.set_last_error(tracer, reason)}
+  end
 end

--- a/lib/eevm/machine_state.ex
+++ b/lib/eevm/machine_state.ex
@@ -25,7 +25,7 @@ defmodule EEVM.MachineState do
   - The `alias` keyword lets us reference modules by their short name.
   """
 
-  alias EEVM.{CallFrame, Memory, Stack}
+  alias EEVM.{CallFrame, Memory, Stack, Tracer}
   alias EEVM.Config
   alias EEVM.Database
   alias EEVM.Database.InMemory, as: InMemoryDB
@@ -59,7 +59,8 @@ defmodule EEVM.MachineState do
           status: status(),
           return_data: binary(),
           logs: [%{address: non_neg_integer(), data: binary(), topics: [non_neg_integer()]}],
-          code: binary()
+          code: binary(),
+          tracer: Tracer.t() | nil
         }
 
   @enforce_keys [:code]
@@ -87,7 +88,8 @@ defmodule EEVM.MachineState do
             status: :running,
             return_data: <<>>,
             logs: [],
-            code: <<>>
+            code: <<>>,
+            tracer: nil
 
   @doc """
   Creates a new machine state for executing the given bytecode.
@@ -111,6 +113,7 @@ defmodule EEVM.MachineState do
       - `:is_static` — static context flag for this frame (default: `false`)
       - `:depth` — current call depth (default: `0`)
       - `:refund` — gas refund counter (default: `0`)
+      - `:tracer` — optional `EEVM.Tracer` to record per-opcode trace (default: `nil`)
 
   ## Example
 
@@ -148,7 +151,8 @@ defmodule EEVM.MachineState do
       depth: Keyword.get(opts, :depth, 0),
       return_data: Keyword.get(opts, :return_data, <<>>),
       gas: Keyword.get(opts, :gas, 1_000_000),
-      refund: Keyword.get(opts, :refund, 0)
+      refund: Keyword.get(opts, :refund, 0),
+      tracer: Keyword.get(opts, :tracer)
     }
   end
 

--- a/lib/eevm/opcodes/system/calls.ex
+++ b/lib/eevm/opcodes/system/calls.ex
@@ -248,7 +248,8 @@ defmodule EEVM.Opcodes.System.Calls do
                 accessed_storage_keys: state_after_touch.accessed_storage_keys,
                 created_addresses: state_after_touch.created_addresses,
                 is_static: state_after_touch.is_static,
-                depth: state_after_touch.depth + 1
+                depth: state_after_touch.depth + 1,
+                tracer: state_after_touch.tracer
               )
 
             child_result = Executor.run_loop(child_state)
@@ -302,6 +303,7 @@ defmodule EEVM.Opcodes.System.Calls do
              |> Map.put(:created_addresses, created_addresses_result)
              |> Map.put(:touched_addresses, touched_addresses_result)
              |> Map.put(:gas, state_after_forward.gas + child_result.gas)
+             |> Map.put(:tracer, child_result.tracer)
              |> MachineState.advance_pc()}
           end
 
@@ -403,7 +405,8 @@ defmodule EEVM.Opcodes.System.Calls do
                 accessed_storage_keys: state_after_touch.accessed_storage_keys,
                 created_addresses: state_after_touch.created_addresses,
                 is_static: state_after_touch.is_static,
-                depth: state_after_touch.depth + 1
+                depth: state_after_touch.depth + 1,
+                tracer: state_after_touch.tracer
               )
 
             child_result = Executor.run_loop(child_state)
@@ -457,6 +460,7 @@ defmodule EEVM.Opcodes.System.Calls do
              |> Map.put(:created_addresses, created_addresses_result)
              |> Map.put(:touched_addresses, touched_addresses_result)
              |> Map.put(:gas, state_after_forward.gas + child_result.gas)
+             |> Map.put(:tracer, child_result.tracer)
              |> MachineState.advance_pc()}
           end
 

--- a/lib/eevm/opcodes/system/creation.ex
+++ b/lib/eevm/opcodes/system/creation.ex
@@ -128,21 +128,25 @@ defmodule EEVM.Opcodes.System.Creation do
                         accessed_storage_keys: state_after_touch.accessed_storage_keys,
                         created_addresses: state_after_touch.created_addresses,
                         is_static: state_after_touch.is_static,
-                        depth: state_after_touch.depth + 1
+                        depth: state_after_touch.depth + 1,
+                        tracer: state_after_touch.tracer
                       )
 
                     child_result = Executor.run_loop(child_state)
                     deployment_success = child_result.status == :stopped
+
+                    post_child_fail_state = %{
+                      state_after_touch
+                      | db: db_after_nonce,
+                        tracer: child_result.tracer
+                    }
 
                     if deployment_success do
                       runtime_code = child_result.return_data
 
                       if HardforkConfig.enabled?(child_result.config.hardfork, :eip_170) and
                            byte_size(runtime_code) > @max_code_size do
-                        create_failed(
-                          %{state_after_touch | db: db_after_nonce},
-                          stack
-                        )
+                        create_failed(post_child_fail_state, stack)
                       else
                         # EIP-3541 (London+): reject runtime code whose first byte is 0xEF.
                         # The 0xEF prefix is reserved for the EVM Object Format (EOF).
@@ -151,10 +155,7 @@ defmodule EEVM.Opcodes.System.Creation do
                         # deposited. Empty runtime code is explicitly allowed.
                         if HardforkConfig.enabled?(child_result.config.hardfork, :eip_3541) and
                              reject_eip_3541_runtime_code?(runtime_code) do
-                          create_failed(
-                            %{state_after_touch | db: db_after_nonce},
-                            stack
-                          )
+                          create_failed(post_child_fail_state, stack)
                         else
                           deposit_cost = Dynamic.code_deposit_cost(byte_size(runtime_code))
 
@@ -187,18 +188,16 @@ defmodule EEVM.Opcodes.System.Creation do
                              |> Map.put(:touched_addresses, child_result.touched_addresses)
                              |> Map.put(:gas, child_result.gas - deposit_cost)
                              |> Map.put(:return_data, child_result.return_data)
+                             |> Map.put(:tracer, child_result.tracer)
                              |> MachineState.advance_pc()}
                           else
-                            create_failed(
-                              %{state_after_touch | db: db_after_nonce},
-                              stack
-                            )
+                            create_failed(post_child_fail_state, stack)
                           end
                         end
                       end
                     else
                       create_failed(
-                        %{state_after_touch | db: db_after_nonce},
+                        post_child_fail_state,
                         stack
                       )
                     end

--- a/lib/eevm/tracer.ex
+++ b/lib/eevm/tracer.ex
@@ -1,0 +1,140 @@
+defmodule EEVM.Tracer do
+  @moduledoc """
+  Opt-in opcode-level execution tracer.
+
+  A tracer is attached to a `MachineState` (via `MachineState.new/2` with
+  `tracer: EEVM.Tracer.new()`). When present, the executor records one
+  `TraceStep` per opcode with pre-execution PC, stack, memory size, and
+  depth plus the actual gas cost charged by that step.
+
+  Output is compatible with the `evm --json` format defined by EIP-3155,
+  so traces can be diffed against geth/revm reference runs.
+
+  ## Performance
+
+  When the `tracer` field is `nil` (default), the executor skips all trace
+  bookkeeping — no snapshot is taken and the tracer branch is a single
+  pattern-match-and-return. Trace capture is opt-in at the call site.
+  """
+
+  alias EEVM.Opcodes.Registry
+
+  defmodule TraceStep do
+    @moduledoc "A single recorded step: one opcode execution in the trace."
+
+    @type t :: %__MODULE__{
+            pc: non_neg_integer(),
+            op: atom(),
+            op_byte: non_neg_integer(),
+            gas_remaining: non_neg_integer(),
+            gas_cost: non_neg_integer(),
+            stack: [non_neg_integer()],
+            memory_size: non_neg_integer(),
+            depth: non_neg_integer(),
+            refund: non_neg_integer(),
+            return_data: binary(),
+            error: atom() | nil
+          }
+
+    defstruct [
+      :pc,
+      :op,
+      :op_byte,
+      :gas_remaining,
+      :gas_cost,
+      :stack,
+      :memory_size,
+      :depth,
+      :refund,
+      :return_data,
+      :error
+    ]
+  end
+
+  @type snapshot :: %{
+          pc: non_neg_integer(),
+          op_byte: non_neg_integer(),
+          op: atom(),
+          gas: non_neg_integer(),
+          stack: [non_neg_integer()],
+          memory_size: non_neg_integer(),
+          depth: non_neg_integer(),
+          refund: non_neg_integer()
+        }
+
+  @type t :: %__MODULE__{steps: [TraceStep.t()]}
+
+  defstruct steps: []
+
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @spec record(t(), TraceStep.t()) :: t()
+  def record(%__MODULE__{steps: steps} = tracer, %TraceStep{} = step) do
+    %{tracer | steps: [step | steps]}
+  end
+
+  @doc "Marks the most recently recorded step with an error reason."
+  @spec set_last_error(t(), atom()) :: t()
+  def set_last_error(%__MODULE__{steps: []} = tracer, _reason), do: tracer
+
+  def set_last_error(%__MODULE__{steps: [last | rest]} = tracer, reason) do
+    %{tracer | steps: [%{last | error: reason} | rest]}
+  end
+
+  @doc "Returns the recorded steps in execution order."
+  @spec steps(t()) :: [TraceStep.t()]
+  def steps(%__MODULE__{steps: steps}), do: Enum.reverse(steps)
+
+  @doc "Returns the opcode name atom for a byte (e.g. `0x01` -> `:ADD`)."
+  @spec op_name(non_neg_integer()) :: atom()
+  def op_name(opcode) do
+    case Registry.info(opcode) do
+      {:ok, %{name: name}} -> String.to_atom(name)
+      {:error, _} -> :UNKNOWN
+    end
+  end
+
+  @doc """
+  Renders the trace as EIP-3155 / geth `--json` compatible JSON lines.
+
+  Returns a list of JSON-encoded strings, one per step. Join with newlines
+  for geth-style output.
+  """
+  @spec to_json_lines(t()) :: [String.t()]
+  def to_json_lines(%__MODULE__{} = tracer) do
+    tracer
+    |> steps()
+    |> Enum.map(&step_to_json/1)
+  end
+
+  @doc "Renders the trace as a single newline-joined JSON string."
+  @spec to_json(t()) :: String.t()
+  def to_json(%__MODULE__{} = tracer) do
+    tracer |> to_json_lines() |> Enum.join("\n")
+  end
+
+  defp step_to_json(%TraceStep{} = step) do
+    base = %{
+      pc: step.pc,
+      op: step.op_byte,
+      gas: hex(step.gas_remaining),
+      gasCost: hex(step.gas_cost),
+      memSize: step.memory_size,
+      stack: Enum.map(Enum.reverse(step.stack), &hex/1),
+      depth: step.depth + 1,
+      refund: step.refund,
+      opName: Atom.to_string(step.op)
+    }
+
+    with_error =
+      case step.error do
+        nil -> base
+        err -> Map.put(base, :error, Atom.to_string(err))
+      end
+
+    Jason.encode!(with_error)
+  end
+
+  defp hex(n) when is_integer(n), do: ("0x" <> Integer.to_string(n, 16)) |> String.downcase()
+end

--- a/test/tracer_test.exs
+++ b/test/tracer_test.exs
@@ -1,0 +1,155 @@
+defmodule EEVM.TracerTest do
+  use ExUnit.Case, async: true
+
+  alias EEVM.Tracer
+  alias EEVM.Tracer.TraceStep
+
+  describe "opt-in behavior" do
+    test "tracer is nil by default — no trace recorded" do
+      state = EEVM.execute(<<0x60, 0x01, 0x60, 0x02, 0x01, 0x00>>)
+      assert state.tracer == nil
+    end
+
+    test "trace/2 attaches a fresh tracer and records every opcode" do
+      # PUSH1 1, PUSH1 2, ADD, STOP
+      {state, tracer} = EEVM.trace(<<0x60, 0x01, 0x60, 0x02, 0x01, 0x00>>)
+      assert state.status == :stopped
+
+      steps = Tracer.steps(tracer)
+      assert length(steps) == 4
+      assert Enum.map(steps, & &1.op) == [:PUSH1, :PUSH1, :ADD, :STOP]
+      assert Enum.map(steps, & &1.pc) == [0, 2, 4, 5]
+    end
+  end
+
+  describe "per-step fields" do
+    # PUSH1 0x0A, PUSH1 0x14, ADD, STOP
+    setup do
+      {_state, tracer} = EEVM.trace(<<0x60, 0x0A, 0x60, 0x14, 0x01, 0x00>>)
+      {:ok, steps: Tracer.steps(tracer)}
+    end
+
+    test "pre-step gas is recorded before static cost is deducted", %{steps: steps} do
+      [push1_a, push1_b, add, stop] = steps
+      # Each PUSH costs 3 gas, ADD costs 3 gas, STOP costs 0. Initial gas = 1_000_000.
+      assert push1_a.gas_remaining == 1_000_000
+      assert push1_a.gas_cost == 3
+
+      assert push1_b.gas_remaining == 999_997
+      assert push1_b.gas_cost == 3
+
+      assert add.gas_remaining == 999_994
+      assert add.gas_cost == 3
+
+      assert stop.gas_remaining == 999_991
+      assert stop.gas_cost == 0
+    end
+
+    test "pre-step stack snapshot is what the opcode reads (top first)", %{steps: steps} do
+      [push1_a, push1_b, add, _stop] = steps
+      assert push1_a.stack == []
+      assert push1_b.stack == [0x0A]
+      # ADD pops the top two elements; before execution the stack has [0x14, 0x0A] top-first.
+      assert add.stack == [0x14, 0x0A]
+    end
+
+    test "depth is 0 for top-level execution", %{steps: steps} do
+      assert Enum.all?(steps, &(&1.depth == 0))
+    end
+
+    test "op_byte and op name agree with the bytecode", %{steps: steps} do
+      [push1_a, _, add, stop] = steps
+      assert push1_a.op == :PUSH1
+      assert push1_a.op_byte == 0x60
+      assert add.op == :ADD
+      assert add.op_byte == 0x01
+      assert stop.op == :STOP
+      assert stop.op_byte == 0x00
+    end
+  end
+
+  describe "error capture" do
+    test "out-of-gas terminates with an error step" do
+      # ADD with empty stack consumes static cost, then errors on pop.
+      # Too little gas even for the static cost:
+      {_state, tracer} = EEVM.trace(<<0x01>>, gas: 2)
+      steps = Tracer.steps(tracer)
+      assert [%TraceStep{op: :ADD, error: :out_of_gas}] = steps
+    end
+
+    test "stack underflow reports the underlying reason" do
+      {state, tracer} = EEVM.trace(<<0x01>>)
+      assert match?({:error, :stack_underflow}, state.status)
+      [step] = Tracer.steps(tracer)
+      assert step.op == :ADD
+      assert step.error == :stack_underflow
+    end
+  end
+
+  describe "nested calls track depth" do
+    test "STATICCALL into a contract bumps depth in the child's trace" do
+      alias EEVM.Context.Contract
+      alias EEVM.Database.InMemory, as: DB
+
+      callee_code = <<0x60, 0x42, 0x00>>
+      callee_addr = 0xC0FFEE
+
+      db =
+        DB.new()
+        |> EEVM.Database.put_code(callee_addr, callee_code)
+
+      # STATICCALL gas addr argsOffset argsSize retOffset retSize
+      # push args in reverse: 0, 0, 0, 0, addr, 0xFFFF
+      caller_code =
+        <<0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x62, 0xC0, 0xFF, 0xEE, 0x61, 0xFF,
+          0xFF, 0xFA, 0x00>>
+
+      {_state, tracer} =
+        EEVM.trace(caller_code,
+          db: db,
+          contract: %{Contract.new() | address: 0xCA11E2}
+        )
+
+      steps = Tracer.steps(tracer)
+      parent_ops = Enum.filter(steps, &(&1.depth == 0))
+      child_ops = Enum.filter(steps, &(&1.depth == 1))
+
+      assert Enum.any?(parent_ops, &(&1.op == :STATICCALL))
+      assert Enum.map(child_ops, & &1.op) == [:PUSH1, :STOP]
+    end
+  end
+
+  describe "JSON output (EIP-3155 / geth --json)" do
+    test "each line is valid JSON with geth-compatible keys" do
+      {_state, tracer} = EEVM.trace(<<0x60, 0x01, 0x00>>)
+      [line1, line2] = Tracer.to_json_lines(tracer)
+
+      decoded1 = Jason.decode!(line1)
+      assert decoded1["op"] == 0x60
+      assert decoded1["opName"] == "PUSH1"
+      assert decoded1["pc"] == 0
+      assert decoded1["depth"] == 1
+      assert decoded1["stack"] == []
+      assert decoded1["memSize"] == 0
+      assert String.starts_with?(decoded1["gas"], "0x")
+      assert String.starts_with?(decoded1["gasCost"], "0x")
+
+      decoded2 = Jason.decode!(line2)
+      assert decoded2["opName"] == "STOP"
+      # After PUSH1, the stack has one element — encoded bottom-first, hex.
+      assert decoded2["stack"] == ["0x1"]
+    end
+
+    test "to_json joins lines with newlines" do
+      {_state, tracer} = EEVM.trace(<<0x60, 0x01, 0x00>>)
+      rendered = Tracer.to_json(tracer)
+      assert length(String.split(rendered, "\n")) == 2
+    end
+
+    test "error steps include an error field" do
+      {_state, tracer} = EEVM.trace(<<0x01>>)
+      [line] = Tracer.to_json_lines(tracer)
+      assert Jason.decode!(line)["error"] == "stack_underflow"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add `EEVM.Tracer` — collects one `TraceStep` per opcode with PC, stack, memory size, gas, depth, refund; steps captured pre-execution so CALL appears before the child's opcodes in chronological order
- thread tracer through CALL/CREATE frame boundaries so nested depth is recorded correctly
- add `EEVM.trace/2` entry point (returns `{state, tracer}`); `EEVM.Tracer.to_json/1` renders EIP-3155 / geth `--json` lines for diffing against reference implementations

Closes #89.

## Design notes

- The tracer is nil by default. The executor's trace hooks pattern-match on `tracer: nil` and return the state unchanged — no snapshot work on the hot path.
- `gas_cost` is recorded as the static cost known pre-execution. Dynamic portions for CALL, SSTORE, EXP, SHA3, etc. are a known limitation of this first cut; ordering and all other fields are accurate.
- Child frames inherit the parent's tracer and write their steps into the same chronological stream; when the child returns, the updated tracer is pulled back into the parent state on both success and failure paths (for CREATE, this includes the size-exceeded / EIP-3541 / insufficient-deposit-gas branches).

## Test plan
- [x] `mix test` — 547 tests, 0 failures (12 new)
- [x] `mix format --check-formatted`
- [x] `mix credo --strict` — no issues
- [x] `mix compile --warnings-as-errors`

Trace tests cover: opt-in default (nil), per-step pc/gas/stack/depth/op, out-of-gas and stack-underflow error capture, nested call depth, JSON shape and error field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)