### PR TITLE
ci: fix BLS NIF load failures on cache restore

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -35,8 +35,11 @@ jobs:
     - name: Restore build cache
       uses: actions/cache@v4
       with:
-        path: _build
-        key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}
+        path: |
+          _build
+          priv/native
+          native/eevm_bls/target
+        key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock', 'native/**/Cargo.lock', 'native/**/Cargo.toml', 'native/**/src/**') }}
         restore-keys: ${{ runner.os }}-build-
     - name: Install dependencies
       run: mix deps.get
@@ -69,8 +72,11 @@ jobs:
     - name: Restore build cache
       uses: actions/cache@v4
       with:
-        path: _build
-        key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}
+        path: |
+          _build
+          priv/native
+          native/eevm_bls/target
+        key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock', 'native/**/Cargo.lock', 'native/**/Cargo.toml', 'native/**/src/**') }}
         restore-keys: ${{ runner.os }}-build-
     - name: Install dependencies
       run: mix deps.get


### PR DESCRIPTION
## Summary

- Cache was restoring a dangling symlink for the BLS12-381 NIF, causing every cached CI run to fail with 10 NIF load errors.
- Expand the cached paths and the cache key so the compiled `.so` and its Rust build artifacts survive restores.

## Root cause

`actions/cache@v4` was only caching `_build/`. Mix symlinks `_build/<env>/lib/eevm/priv` to the project-root `priv/`, so the actual artifact (`priv/native/eevm_bls.so`) lives outside the cached path. On a cold run the NIF is freshly built and loads fine; on subsequent runs the restored cache contains a symlink pointing nowhere, and every BLS precompile test fails at module load.

## Fix

- Add `priv/native` and `native/eevm_bls/target` to `path:` so the compiled NIF and its Rust target dir are both cached.
- Add `native/**/Cargo.lock`, `native/**/Cargo.toml`, and `native/**/src/**` to the cache key so edits to the Rust source invalidate the cache.

## Test plan

- [ ] First run on this PR: cold build, all tests pass.
- [ ] Re-run the workflow: cache is restored and BLS precompile tests still pass (this is the failure mode the fix targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)