### PR TITLE
feat: implement beacon block root contract (EIP-4788)

### DIFF
--- a/lib/eevm/context/block.ex
+++ b/lib/eevm/context/block.ex
@@ -22,6 +22,14 @@ defmodule EEVM.Context.Block do
   | `blob_base_fee` | BLOBBASEFEE (0x4A) | Block blob base fee from EIP-7516 |
   | `chain_id` | CHAINID (0x46) | Network ID (1=mainnet, 137=Polygon, etc.) |
   | `hashes` | BLOCKHASH (0x40) | Map of recent block numbers to their hashes |
+  | `parent_beacon_block_root` | (no opcode) | Parent beacon block root (EIP-4788) |
+
+  ### parent_beacon_block_root
+
+  Added in Cancun (EIP-4788). Not exposed through an opcode — instead, the EL
+  client performs a system call into the beacon-roots contract at block start
+  to record this value keyed by the parent block's timestamp. User contracts
+  then `CALL` that contract to read historical beacon roots.
 
   ### PREVRANDAO
 
@@ -45,7 +53,8 @@ defmodule EEVM.Context.Block do
           basefee: non_neg_integer(),
           blob_base_fee: non_neg_integer(),
           chain_id: non_neg_integer(),
-          hashes: %{non_neg_integer() => non_neg_integer()}
+          hashes: %{non_neg_integer() => non_neg_integer()},
+          parent_beacon_block_root: non_neg_integer()
         }
 
   defstruct number: 0,
@@ -56,7 +65,8 @@ defmodule EEVM.Context.Block do
             basefee: 0,
             blob_base_fee: 0,
             chain_id: 1,
-            hashes: %{}
+            hashes: %{},
+            parent_beacon_block_root: 0
 
   @doc "Creates a new block context with default values."
   @spec new() :: t()

--- a/lib/eevm/hardfork_config.ex
+++ b/lib/eevm/hardfork_config.ex
@@ -106,6 +106,8 @@ defmodule EEVM.HardforkConfig do
     eip_5656: :cancun,
     # EIP-6780 (Cancun): SELFDESTRUCT only deletes if created this tx
     eip_6780: :cancun,
+    # EIP-4788 (Cancun): parent beacon block root system contract at 0x000F3df6...Beac02
+    eip_4788: :cancun,
     # EIP-2537 (Prague): BLS12-381 precompiles at 0x0B-0x11
     eip_2537: :prague,
     # EIP-7623 (Prague): calldata floor pricing

--- a/lib/eevm/system_contracts/beacon_roots.ex
+++ b/lib/eevm/system_contracts/beacon_roots.ex
@@ -1,0 +1,163 @@
+defmodule EEVM.SystemContracts.BeaconRoots do
+  @moduledoc """
+  EIP-4788 beacon block root contract.
+
+  ## EVM Concepts
+
+  Before Cancun the consensus-layer (CL) beacon block root was invisible to
+  the EVM. EIP-4788 bridges that gap with an ordinary contract deployed at a
+  well-known address:
+
+      0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02
+
+  At the start of every block the execution client performs a *system call*
+  into this contract with the parent beacon-block root as calldata, signed as
+  coming from the SYSTEM_ADDRESS (`0xff..fe`). The contract keys the root by
+  the current block timestamp and stashes it in a ring buffer of
+  `HISTORY_BUFFER_LENGTH = 8191` slots. User contracts later `CALL` the same
+  address with a 32-byte timestamp to read back the root.
+
+  Storage layout (per the EIP):
+
+  - `storage[timestamp % 8191]`           = timestamp
+  - `storage[(timestamp % 8191) + 8191]`  = beacon_root
+
+  On read, the contract verifies the timestamp slot matches the queried
+  timestamp (so collisions from the ring buffer return an empty result
+  instead of a stale root).
+
+  ## Design
+
+  We do not invent a custom precompile. Instead we install the exact deployed
+  bytecode specified by the EIP at the canonical address and drive it through
+  the normal executor — the same code path any CALL would take. This keeps
+  behavior faithful to mainnet and means any future changes to CALL semantics
+  come along for free.
+
+  - `install/1` — place the deployed bytecode into a `Database`.
+  - `commit/3`  — perform the block-start system call that stores a root.
+  - `lookup/2`  — read a stored root directly from storage (convenience).
+
+  `commit/3` returns `{:ok, updated_db}` on success and `{:error, reason, db}`
+  on an execution failure; the caller decides what to do about it.
+
+  ## Elixir Learning Notes
+
+  - The deployed bytecode lives as a compile-time constant via `@deployed_code`
+    so there is no per-call decoding cost.
+  - `install/1` and `commit/3` both work on plain `Database` values — no
+    `MachineState` is exposed to callers — keeping the integration surface
+    small for higher layers that aren't yet aware of full EVM state.
+  """
+
+  alias EEVM.{Database, Executor, HardforkConfig, MachineState}
+  alias EEVM.Context.{Block, Contract, Transaction}
+
+  @address 0x000F3DF6D732807EF1319FB7B8BB8522D0BEAC02
+  @system_address 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE
+  @history_buffer_length 8191
+  @system_call_gas 30_000_000
+
+  # Deployed runtime bytecode from EIP-4788, section "Deployment".
+  @deployed_code Base.decode16!(
+                   "3373FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE14604D57602036146024" <>
+                     "575F5FFD5B5F35801560495762001FFF810690815414603C575F5FFD5B62001F" <>
+                     "FF01545F5260205FF35B5F5FFD5B62001FFF42064281555F359062001FFF0155" <>
+                     "00"
+                 )
+
+  @doc "Canonical deployment address of the beacon-roots contract."
+  @spec address() :: non_neg_integer()
+  def address, do: @address
+
+  @doc "Caller address used by the execution layer's block-start system call."
+  @spec system_address() :: non_neg_integer()
+  def system_address, do: @system_address
+
+  @doc "Ring-buffer size for beacon-root history (constant, 8191)."
+  @spec history_buffer_length() :: pos_integer()
+  def history_buffer_length, do: @history_buffer_length
+
+  @doc "Returns the exact deployed bytecode that the EIP specifies."
+  @spec deployed_bytecode() :: binary()
+  def deployed_bytecode, do: @deployed_code
+
+  @doc """
+  Installs the beacon-roots contract into `db` at the canonical address.
+
+  Idempotent — re-installing leaves storage untouched and only ensures the
+  code is present.
+  """
+  @spec install(Database.t()) :: Database.t()
+  def install(%Database{} = db) do
+    Database.put_code(db, @address, @deployed_code)
+  end
+
+  @doc """
+  Installs only if EIP-4788 is active in the given hardfork config. Callers
+  setting up a pre-Cancun genesis get a no-op.
+  """
+  @spec install_if_enabled(Database.t(), HardforkConfig.t()) :: Database.t()
+  def install_if_enabled(%Database{} = db, %HardforkConfig{} = config) do
+    if HardforkConfig.enabled?(config, :eip_4788), do: install(db), else: db
+  end
+
+  @doc """
+  Executes the block-start system call that records `beacon_root` under
+  `block.timestamp`.
+
+  Uses SYSTEM_ADDRESS as the caller so the contract takes its storage branch.
+  Returns the updated database, or an error tuple if the call reverted (which
+  should never happen with the canonical bytecode, but we surface it rather
+  than swallow it).
+  """
+  @spec commit(Database.t(), Block.t(), non_neg_integer()) ::
+          {:ok, Database.t()} | {:error, atom(), Database.t()}
+  def commit(%Database{} = db, %Block{} = block, beacon_root)
+      when is_integer(beacon_root) and beacon_root >= 0 do
+    calldata = <<beacon_root::unsigned-big-256>>
+
+    final_state =
+      @deployed_code
+      |> MachineState.new(
+        db: db,
+        block: block,
+        tx: %Transaction{origin: @system_address},
+        contract: %Contract{
+          address: @address,
+          caller: @system_address,
+          callvalue: 0,
+          calldata: calldata
+        },
+        gas: @system_call_gas
+      )
+      |> Executor.run_loop()
+
+    # RETURN and STOP both halt with :stopped in this VM; the distinction is
+    # whether return_data was populated. A :reverted status means the contract
+    # rejected the call (malformed calldata / bad caller).
+    case final_state.status do
+      :stopped -> {:ok, final_state.db}
+      other -> {:error, other, final_state.db}
+    end
+  end
+
+  @doc """
+  Reads a previously-committed beacon root by timestamp, directly from the
+  contract's storage slots.
+
+  Returns `{:ok, root}` when the slot at `timestamp % 8191` matches
+  `timestamp` (i.e. no ring-buffer collision), and `:not_found` otherwise.
+  """
+  @spec lookup(Database.t(), non_neg_integer()) :: {:ok, non_neg_integer()} | :not_found
+  def lookup(%Database{} = db, timestamp) when is_integer(timestamp) and timestamp >= 0 do
+    index = rem(timestamp, @history_buffer_length)
+    stored_ts = Database.storage_load(db, @address, index)
+
+    if stored_ts == timestamp do
+      {:ok, Database.storage_load(db, @address, index + @history_buffer_length)}
+    else
+      :not_found
+    end
+  end
+end

--- a/test/system_contracts/beacon_roots_test.exs
+++ b/test/system_contracts/beacon_roots_test.exs
@@ -1,0 +1,133 @@
+defmodule EEVM.SystemContracts.BeaconRootsTest do
+  use ExUnit.Case, async: true
+
+  alias EEVM.Database.InMemory
+  alias EEVM.{Database, HardforkConfig, MachineState}
+  alias EEVM.Context.{Block, Contract, Transaction}
+  alias EEVM.SystemContracts.BeaconRoots
+
+  @history 8191
+
+  describe "install/1" do
+    test "places the deployed bytecode at the canonical address" do
+      db = BeaconRoots.install(InMemory.new())
+
+      assert Database.get_code(db, BeaconRoots.address()) == BeaconRoots.deployed_bytecode()
+    end
+
+    test "is idempotent — re-installing leaves storage untouched" do
+      db =
+        InMemory.new()
+        |> BeaconRoots.install()
+        |> Database.storage_store(BeaconRoots.address(), 42, 0xABC)
+        |> BeaconRoots.install()
+
+      assert Database.storage_load(db, BeaconRoots.address(), 42) == 0xABC
+    end
+  end
+
+  describe "install_if_enabled/2" do
+    test "installs under Cancun+" do
+      db = BeaconRoots.install_if_enabled(InMemory.new(), HardforkConfig.new(:cancun))
+      assert Database.get_code(db, BeaconRoots.address()) == BeaconRoots.deployed_bytecode()
+    end
+
+    test "is a no-op pre-Cancun" do
+      db = BeaconRoots.install_if_enabled(InMemory.new(), HardforkConfig.new(:shanghai))
+      assert Database.get_code(db, BeaconRoots.address()) == <<>>
+    end
+  end
+
+  describe "commit/3" do
+    test "stores timestamp and root in the ring-buffer slots" do
+      db = BeaconRoots.install(InMemory.new())
+      block = %Block{timestamp: 1_700_000_000}
+      root = 0xDEADBEEFCAFEBABE0000000000000000000000000000000000000000FACEFEED
+
+      {:ok, db} = BeaconRoots.commit(db, block, root)
+
+      index = rem(1_700_000_000, @history)
+      assert Database.storage_load(db, BeaconRoots.address(), index) == 1_700_000_000
+      assert Database.storage_load(db, BeaconRoots.address(), index + @history) == root
+    end
+
+    test "lookup/2 round-trips a committed root" do
+      db = BeaconRoots.install(InMemory.new())
+      block = %Block{timestamp: 1_700_000_000}
+      root = 0xFEED0001
+
+      {:ok, db} = BeaconRoots.commit(db, block, root)
+
+      assert BeaconRoots.lookup(db, 1_700_000_000) == {:ok, root}
+    end
+
+    test "lookup/2 returns :not_found for unknown timestamps" do
+      db = BeaconRoots.install(InMemory.new())
+      assert BeaconRoots.lookup(db, 42) == :not_found
+    end
+
+    test "ring buffer overwrites when timestamps collide mod 8191" do
+      db = BeaconRoots.install(InMemory.new())
+
+      {:ok, db} = BeaconRoots.commit(db, %Block{timestamp: 1_000}, 0xAAAA)
+      {:ok, db} = BeaconRoots.commit(db, %Block{timestamp: 1_000 + @history}, 0xBBBB)
+
+      # The older timestamp now fails the verify check — ring slot belongs to the newer one.
+      assert BeaconRoots.lookup(db, 1_000) == :not_found
+      assert BeaconRoots.lookup(db, 1_000 + @history) == {:ok, 0xBBBB}
+    end
+  end
+
+  describe "user CALL to the contract" do
+    test "returns the stored beacon root when queried by timestamp" do
+      timestamp = 1_700_000_000
+
+      root =
+        0x1111111111111111111111111111111111111111111111111111111111111111
+
+      db = BeaconRoots.install(InMemory.new())
+      {:ok, db} = BeaconRoots.commit(db, %Block{timestamp: timestamp}, root)
+
+      # Execute the contract directly as a user would via CALL: non-system caller,
+      # 32-byte timestamp calldata. The bytecode must MSTORE+RETURN the root.
+      final_state =
+        BeaconRoots.deployed_bytecode()
+        |> MachineState.new(
+          db: db,
+          block: %Block{timestamp: timestamp},
+          tx: %Transaction{origin: 0xCAFE},
+          contract: %Contract{
+            address: BeaconRoots.address(),
+            caller: 0xCAFE,
+            calldata: <<timestamp::unsigned-big-256>>
+          },
+          gas: 1_000_000
+        )
+        |> EEVM.Executor.run_loop()
+
+      assert final_state.status == :stopped
+      assert byte_size(final_state.return_data) == 32
+      <<returned_root::unsigned-big-256>> = final_state.return_data
+      assert returned_root == root
+    end
+
+    test "reverts on an unknown timestamp" do
+      db = BeaconRoots.install(InMemory.new())
+
+      final_state =
+        BeaconRoots.deployed_bytecode()
+        |> MachineState.new(
+          db: db,
+          contract: %Contract{
+            address: BeaconRoots.address(),
+            caller: 0xCAFE,
+            calldata: <<999::unsigned-big-256>>
+          },
+          gas: 1_000_000
+        )
+        |> EEVM.Executor.run_loop()
+
+      assert final_state.status == :reverted
+    end
+  end
+end


### PR DESCRIPTION
Closes #82.

## Summary

Install the parent-beacon-block-root system contract at the canonical
address `0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02` (Cancun+) and drive
its block-start deposit through the normal executor.

- `eip_4788` added to `HardforkConfig`, active from Cancun.
- `parent_beacon_block_root` added to `Context.Block`.
- New `EEVM.SystemContracts.BeaconRoots`:
  - `install/1` / `install_if_enabled/2` — deploy the EIP's exact runtime bytecode.
  - `commit/3` — run the block-start system call (caller = `SYSTEM_ADDRESS`, calldata = 32-byte root) through `Executor.run_loop`; stores into the 8191-slot ring buffer.
  - `lookup/2` — direct storage read.

## Design notes

No custom precompile — we deploy the exact runtime bytecode specified by the EIP and call it through the real executor. Any future CALL-semantic changes come along for free, and the tests exercise the real bytecode, not a reimplementation.

`commit/3` and `lookup/2` take/return a `Database`, keeping the integration surface small for higher layers (block processing in #86 will hook this in at block boundaries).

## Test plan

- [x] `install/1` places bytecode, is idempotent.
- [x] `install_if_enabled/2` gates on Cancun.
- [x] `commit/3` populates both ring-buffer slots (`ts % 8191` and `+ 8191`).
- [x] `lookup/2` round-trips a stored root.
- [x] `lookup/2` returns `:not_found` for unknown timestamps.
- [x] Ring-buffer collisions overwrite old entries correctly.
- [x] User `CALL` with a known timestamp returns the 32-byte root via RETURN.
- [x] User `CALL` with an unknown timestamp reverts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)