### PR TITLE
feat: add block-level transaction processor

### DIFF
--- a/lib/eevm/block/header.ex
+++ b/lib/eevm/block/header.ex
@@ -1,0 +1,88 @@
+defmodule EEVM.Block.Header do
+  @moduledoc """
+  Ethereum block header — the consensus-critical metadata for a block.
+
+  ## EVM Concepts
+
+  A block header is a thin descriptor of a block. It advertises the pre-state
+  parent pointers, the execution parameters (gas limit, base fee, randomness),
+  and the post-execution commitments (state / receipts / transactions roots
+  plus the aggregated logs bloom).
+
+  The execution client is responsible for checking that the post-execution
+  commitments it computes match the ones advertised here. This struct is a
+  pure data carrier — validation lives in `EEVM.Block.Processor`.
+
+  ### Fields
+
+  | Field | Description |
+  |-------|-------------|
+  | `number` | Block number (height on the chain) |
+  | `parent_hash` | Keccak hash of the parent header |
+  | `timestamp` | Block timestamp in seconds since epoch |
+  | `coinbase` | Address of the block producer (fee recipient) |
+  | `gas_limit` | Maximum cumulative gas the block may consume |
+  | `base_fee_per_gas` | EIP-1559 base fee |
+  | `prev_randao` | RANDAO mix inherited from the beacon chain (post-Merge) |
+  | `parent_beacon_block_root` | EIP-4788 beacon root pointer from the parent slot |
+  | `state_root` | Post-execution world-state MPT root |
+  | `receipts_root` | MPT root of `{rlp(index) => rlp(receipt)}` |
+  | `transactions_root` | MPT root of `{rlp(index) => rlp(transaction)}` |
+  | `logs_bloom` | 256-byte bloom summarising every log in the block |
+
+  ## Elixir Learning Notes
+
+  - This module defines only a struct plus tiny constructors. The field types
+    deliberately mirror `EEVM.Context.Block` where they overlap so callers can
+    move values between the "what the network says" layer (`Header`) and the
+    "what opcodes see" layer (`Context.Block`) without impedance.
+  - `new/0` and `new/1` follow the same zero-arg / keyword-override idiom used
+    by the rest of the codebase.
+  """
+
+  @type t :: %__MODULE__{
+          number: non_neg_integer(),
+          parent_hash: binary(),
+          timestamp: non_neg_integer(),
+          coinbase: non_neg_integer(),
+          gas_limit: non_neg_integer(),
+          base_fee_per_gas: non_neg_integer(),
+          prev_randao: non_neg_integer(),
+          parent_beacon_block_root: non_neg_integer(),
+          state_root: binary(),
+          receipts_root: binary(),
+          transactions_root: binary(),
+          logs_bloom: binary()
+        }
+
+  defstruct number: 0,
+            parent_hash: <<0::256>>,
+            timestamp: 0,
+            coinbase: 0,
+            gas_limit: 0,
+            base_fee_per_gas: 0,
+            prev_randao: 0,
+            parent_beacon_block_root: 0,
+            state_root: <<0::256>>,
+            receipts_root: <<0::256>>,
+            transactions_root: <<0::256>>,
+            logs_bloom: <<0::2048>>
+
+  @doc "Returns a zero-initialised header."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc """
+  Returns a header with the given overrides.
+
+  ## Example
+
+      iex> header = EEVM.Block.Header.new(number: 18_000_000, gas_limit: 30_000_000)
+      iex> {header.number, header.gas_limit}
+      {18_000_000, 30_000_000}
+  """
+  @spec new(keyword()) :: t()
+  def new(opts) when is_list(opts) do
+    struct!(__MODULE__, opts)
+  end
+end

--- a/lib/eevm/block/processor.ex
+++ b/lib/eevm/block/processor.ex
@@ -1,0 +1,290 @@
+defmodule EEVM.Block.Processor do
+  @moduledoc """
+  Execute a block end-to-end: system calls, then transactions in order, then
+  the commitments a consensus-level verifier will check.
+
+  ## EVM Concepts
+
+  A block is not just a bag of transactions. The execution client must:
+
+  1. Fire any *system calls* the active hardfork mandates before user code
+     runs. Post-Cancun this is EIP-4788 (beacon roots) and post-Prague this
+     is EIP-2935 (historical block hashes).
+  2. Reject the block outright if the transactions, taken together, declare
+     more gas than the header allows.
+  3. Execute each transaction against the evolving state, recording a receipt
+     whose `cumulative_gas_used` is the running total across the block.
+  4. Produce the three MPT roots — `state_root`, `transactions_root`,
+     `receipts_root` — plus the aggregated `logs_bloom` and the block
+     `gas_used` figure. These are what external verifiers compare against the
+     header.
+
+  If any transaction fails (the injected executor returns an `{:error, _}`)
+  the processor halts and reports the failing index. The post-state database
+  is left at whatever the last *successful* transaction produced — this
+  processor does not attempt optimistic rollback.
+
+  ## Design: dependency injection
+
+  The issues that own the real transaction executor (#83) and the real
+  system-call hooks (#81 EIP-2935 / #82 EIP-4788) are being developed on
+  parallel branches and are not yet merged. To keep this PR independently
+  mergeable, we do not `alias` those modules here — callers pass them in:
+
+  - `:tx_executor` — `(tx, %Context.Block{}, %Database{}) ->
+    {:ok, tx_result} | {:error, reason}`. Each call receives the *current*
+    database after all prior transactions and system calls have been
+    applied. The returned `tx_result` is a map with keys `:status`,
+    `:gas_used`, `:logs`, and `:db`.
+  - `:system_calls` — list of hooks, each `(%Database{}, %Context.Block{})
+    -> %Database{}`. Executed in order, strictly before any transaction.
+    The default is `[]`.
+  - `:tx_encoder` — `(tx) -> binary` used to compute the
+    `transactions_root`. Defaults to `EEVM.Transaction.Envelope.encode/1`,
+    which handles every typed envelope this codebase knows about. Tests
+    using plain maps supply their own.
+  - `:hardfork` — optional atom, purely informational today; the real
+    executor will consume it once wired in.
+
+  Once #83 / #81 / #82 land, a follow-up PR will set sensible defaults for
+  `:tx_executor` and supply the real system-call hooks; until then callers
+  inject their own.
+
+  ## Elixir Learning Notes
+
+  - The transaction fold uses `Enum.reduce_while/3` so we can bail out
+    early on the first executor error without recursing manually.
+  - The receipts / transactions trie roots use `EEVM.MPT.Trie.root_hash/1`
+    (non-secure — keys are RLP-encoded indices, not hashes), matching the
+    Yellow Paper's specification for block-level tries.
+  - The logs-bloom aggregation reuses `EEVM.Bloom.merge/2`: a 256-byte
+    bitwise OR already optimised in the bloom module.
+  """
+
+  alias EEVM.Block.{Header, Receipt}
+  alias EEVM.{Bloom, BlockResult, Database, StateRoot}
+  alias EEVM.Context.Block, as: BlockCtx
+  alias EEVM.MPT.Trie
+  alias EEVM.Transaction.Envelope
+
+  @type tx_result :: %{
+          required(:status) => 0 | 1,
+          required(:gas_used) => non_neg_integer(),
+          required(:logs) => [Bloom.log_entry()],
+          required(:db) => Database.t()
+        }
+
+  @type tx_executor :: (term(), BlockCtx.t(), Database.t() ->
+                          {:ok, tx_result()} | {:error, term()})
+
+  @type system_call :: (Database.t(), BlockCtx.t() -> Database.t())
+
+  @type tx_encoder :: (term() -> binary())
+
+  @type process_opts :: [
+          tx_executor: tx_executor(),
+          system_calls: [system_call()],
+          tx_encoder: tx_encoder(),
+          hardfork: atom() | nil
+        ]
+
+  @type process_error ::
+          :block_gas_limit_exceeded
+          | {:tx_failed, non_neg_integer(), term()}
+
+  @doc """
+  Execute every phase of the block and produce a `%EEVM.BlockResult{}`.
+
+  The caller owns `pre_state_db` and must pass an injected `:tx_executor`.
+  See the module doc for the full option list.
+
+  Returns:
+
+  - `{:ok, %BlockResult{}}` on success.
+  - `{:error, :block_gas_limit_exceeded}` when `sum(tx.gas_limit)` exceeds
+    `header.gas_limit`.
+  - `{:error, {:tx_failed, index, reason}}` when the injected executor
+    rejects a transaction. `index` is 0-based in `transactions` order.
+  """
+  @spec process_block(Header.t(), [term()], Database.t(), process_opts()) ::
+          {:ok, BlockResult.t()} | {:error, process_error()}
+  def process_block(%Header{} = header, transactions, %Database{} = pre_state_db, opts)
+      when is_list(transactions) and is_list(opts) do
+    tx_executor = fetch_executor!(opts)
+    system_calls = Keyword.get(opts, :system_calls, [])
+    tx_encoder = Keyword.get(opts, :tx_encoder, &Envelope.encode/1)
+
+    block_ctx = to_block_ctx(header)
+
+    with :ok <- check_block_gas_limit(header, transactions) do
+      db_after_system = apply_system_calls(pre_state_db, block_ctx, system_calls)
+
+      case execute_transactions(transactions, block_ctx, db_after_system, tx_executor) do
+        {:ok, receipts, post_db, gas_used} ->
+          {:ok, build_result(post_db, receipts, transactions, gas_used, tx_encoder)}
+
+        {:error, _} = error ->
+          error
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Phase 1 — block-level gas check
+  # ---------------------------------------------------------------------------
+
+  @spec check_block_gas_limit(Header.t(), [term()]) :: :ok | {:error, :block_gas_limit_exceeded}
+  defp check_block_gas_limit(%Header{gas_limit: block_gas_limit}, transactions) do
+    declared = Enum.reduce(transactions, 0, fn tx, acc -> acc + tx_gas_limit(tx) end)
+
+    if declared > block_gas_limit do
+      {:error, :block_gas_limit_exceeded}
+    else
+      :ok
+    end
+  end
+
+  # Works for any struct or map carrying a `:gas_limit` field — that's every
+  # envelope struct and every plausible test double. Anything without the
+  # field counts as zero gas so callers aren't forced to pad stubs.
+  @spec tx_gas_limit(term()) :: non_neg_integer()
+  defp tx_gas_limit(%{gas_limit: gas_limit}) when is_integer(gas_limit) and gas_limit >= 0,
+    do: gas_limit
+
+  defp tx_gas_limit(_tx), do: 0
+
+  # ---------------------------------------------------------------------------
+  # Phase 2 — system calls (EIP-4788 / EIP-2935 etc. inject here)
+  # ---------------------------------------------------------------------------
+
+  @spec apply_system_calls(Database.t(), BlockCtx.t(), [system_call()]) :: Database.t()
+  defp apply_system_calls(db, block_ctx, system_calls) do
+    Enum.reduce(system_calls, db, fn hook, db_acc -> hook.(db_acc, block_ctx) end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Phase 3 — transaction fold with cumulative gas tracking
+  # ---------------------------------------------------------------------------
+
+  @spec execute_transactions([term()], BlockCtx.t(), Database.t(), tx_executor()) ::
+          {:ok, [Receipt.t()], Database.t(), non_neg_integer()}
+          | {:error, {:tx_failed, non_neg_integer(), term()}}
+  defp execute_transactions(transactions, block_ctx, db, tx_executor) do
+    initial = {[], db, 0, 0}
+
+    transactions
+    |> Enum.reduce_while(initial, fn tx, {receipts, db_acc, cumulative_gas, index} ->
+      case tx_executor.(tx, block_ctx, db_acc) do
+        {:ok, %{status: status, gas_used: gas_used, logs: logs, db: new_db}} ->
+          new_cumulative = cumulative_gas + gas_used
+
+          receipt = %Receipt{
+            status: status,
+            cumulative_gas_used: new_cumulative,
+            logs: logs,
+            logs_bloom: Bloom.from_logs(logs)
+          }
+
+          {:cont, {[receipt | receipts], new_db, new_cumulative, index + 1}}
+
+        {:error, reason} ->
+          {:halt, {:error, {:tx_failed, index, reason}}}
+      end
+    end)
+    |> case do
+      {:error, _} = error ->
+        error
+
+      {receipts, post_db, cumulative_gas, _index} ->
+        {:ok, Enum.reverse(receipts), post_db, cumulative_gas}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Phase 4 — commitments
+  # ---------------------------------------------------------------------------
+
+  @spec build_result(
+          Database.t(),
+          [Receipt.t()],
+          [term()],
+          non_neg_integer(),
+          tx_encoder()
+        ) :: BlockResult.t()
+  defp build_result(post_db, receipts, transactions, gas_used, tx_encoder) do
+    %BlockResult{
+      post_state_db: post_db,
+      receipts: receipts,
+      state_root: StateRoot.compute_state_root(post_db),
+      receipts_root: compute_receipts_root(receipts),
+      transactions_root: compute_transactions_root(transactions, tx_encoder),
+      logs_bloom: aggregate_logs_bloom(receipts),
+      gas_used: gas_used
+    }
+  end
+
+  @spec compute_receipts_root([Receipt.t()]) :: binary()
+  defp compute_receipts_root(receipts) do
+    receipts
+    |> Enum.with_index()
+    |> Enum.map(fn {receipt, index} -> {ExRLP.encode(index), encode_receipt(receipt)} end)
+    |> Trie.root_hash()
+  end
+
+  @spec compute_transactions_root([term()], tx_encoder()) :: binary()
+  defp compute_transactions_root(transactions, tx_encoder) do
+    transactions
+    |> Enum.with_index()
+    |> Enum.map(fn {tx, index} -> {ExRLP.encode(index), tx_encoder.(tx)} end)
+    |> Trie.root_hash()
+  end
+
+  @spec aggregate_logs_bloom([Receipt.t()]) :: Bloom.t()
+  defp aggregate_logs_bloom(receipts) do
+    Enum.reduce(receipts, Bloom.empty(), fn %Receipt{logs_bloom: bloom}, acc ->
+      Bloom.merge(acc, bloom)
+    end)
+  end
+
+  # Byzantium-and-later receipt layout: [status, cumulativeGasUsed, bloom, logs].
+  @spec encode_receipt(Receipt.t()) :: binary()
+  defp encode_receipt(%Receipt{} = receipt) do
+    encoded_logs =
+      Enum.map(receipt.logs, fn %{address: address, topics: topics, data: data} ->
+        [<<address::unsigned-big-160>>, Enum.map(topics, &<<&1::unsigned-big-256>>), data]
+      end)
+
+    ExRLP.encode([receipt.status, receipt.cumulative_gas_used, receipt.logs_bloom, encoded_logs])
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  @spec fetch_executor!(process_opts()) :: tx_executor()
+  defp fetch_executor!(opts) do
+    case Keyword.fetch(opts, :tx_executor) do
+      {:ok, executor} when is_function(executor, 3) ->
+        executor
+
+      {:ok, _other} ->
+        raise ArgumentError, ":tx_executor must be a 3-arity function"
+
+      :error ->
+        raise ArgumentError, ":tx_executor is required"
+    end
+  end
+
+  @spec to_block_ctx(Header.t()) :: BlockCtx.t()
+  defp to_block_ctx(%Header{} = header) do
+    %BlockCtx{
+      number: header.number,
+      timestamp: header.timestamp,
+      coinbase: header.coinbase,
+      gaslimit: header.gas_limit,
+      prevrandao: header.prev_randao,
+      basefee: header.base_fee_per_gas,
+      parent_beacon_block_root: header.parent_beacon_block_root
+    }
+  end
+end

--- a/lib/eevm/block/receipt.ex
+++ b/lib/eevm/block/receipt.ex
@@ -1,0 +1,73 @@
+defmodule EEVM.Block.Receipt do
+  @moduledoc """
+  Per-transaction receipt emitted after execution.
+
+  ## EVM Concepts
+
+  A receipt is the execution-layer's summary of what happened when a transaction
+  ran. It does not carry the full transaction payload — instead it records the
+  post-conditions an observer needs to validate state transitions:
+
+  - `status` — `1` if the top-level call completed, `0` if it reverted. The
+    Byzantium hardfork replaced the pre-image `state_root` field with this
+    one-byte status code; this module follows that modern layout.
+  - `cumulative_gas_used` — total gas consumed in the block up to and including
+    this transaction. Per the Yellow Paper, receipts are ordered and the
+    `cumulative_gas_used` of the last receipt equals the block's `gas_used`.
+  - `logs` — every log entry emitted by this transaction, in emission order.
+    Each log is a map matching `EEVM.Bloom.log_entry/0`.
+  - `logs_bloom` — the 2048-bit bloom filter over this receipt's logs, i.e.
+    `EEVM.Bloom.from_logs(logs)`. We store it pre-computed so block-level
+    aggregation is a fast bytewise OR.
+
+  The processor fills in `cumulative_gas_used` and `logs_bloom` after each
+  transaction; the injected tx executor is only responsible for the raw
+  status / gas / logs triple.
+
+  ## Elixir Learning Notes
+
+  - This is a thin struct — no logic. Constructors default to a successful
+    receipt with no logs so tests can build interesting cases with just the
+    overrides that matter.
+  - The `logs` type mirrors `EEVM.Bloom.log_entry/0` exactly to keep the
+    two modules compatible without mutual imports.
+  """
+
+  alias EEVM.Bloom
+
+  @type log :: Bloom.log_entry()
+
+  @type t :: %__MODULE__{
+          status: 0 | 1,
+          cumulative_gas_used: non_neg_integer(),
+          logs: [log()],
+          logs_bloom: Bloom.t()
+        }
+
+  defstruct status: 1,
+            cumulative_gas_used: 0,
+            logs: [],
+            logs_bloom: <<0::2048>>
+
+  @doc "Returns a successful receipt with no logs and zero cumulative gas."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc """
+  Returns a receipt with the given overrides.
+
+  If `:logs` is supplied without an explicit `:logs_bloom`, the bloom is
+  derived from the logs automatically so callers cannot produce a receipt
+  whose bloom is out of sync with its logs.
+  """
+  @spec new(keyword()) :: t()
+  def new(opts) when is_list(opts) do
+    base = struct!(__MODULE__, opts)
+
+    cond do
+      Keyword.has_key?(opts, :logs_bloom) -> base
+      Keyword.has_key?(opts, :logs) -> %{base | logs_bloom: Bloom.from_logs(base.logs)}
+      true -> base
+    end
+  end
+end

--- a/lib/eevm/block_result.ex
+++ b/lib/eevm/block_result.ex
@@ -1,0 +1,52 @@
+defmodule EEVM.BlockResult do
+  @moduledoc """
+  The outcome of executing a block — the post-state database plus every
+  commitment derived from it.
+
+  ## EVM Concepts
+
+  `EEVM.Block.Processor.process_block/4` returns one of these on success. The
+  fields line up with the header commitments a verifier would check against
+  the advertised `EEVM.Block.Header`:
+
+  - `post_state_db` — the `EEVM.Database` after system calls and every
+    transaction have been applied in order.
+  - `receipts` — the per-transaction receipts, already carrying their
+    `cumulative_gas_used` figures.
+  - `state_root` — post-execution world-state MPT root.
+  - `receipts_root` — MPT root of `{rlp(index) => rlp(receipt)}`.
+  - `transactions_root` — MPT root of `{rlp(index) => rlp(transaction)}`.
+  - `logs_bloom` — bitwise OR of every receipt's logs bloom.
+  - `gas_used` — total gas consumed across all transactions (matches
+    the final receipt's `cumulative_gas_used`, `0` when the block is empty).
+
+  ## Elixir Learning Notes
+
+  - This struct is intentionally a value type: the processor builds it once
+    at the end of `process_block/4` and hands it back unchanged. No helper
+    mutators live here.
+  """
+
+  alias EEVM.Block.Receipt
+  alias EEVM.{Bloom, Database}
+
+  @type t :: %__MODULE__{
+          post_state_db: Database.t(),
+          receipts: [Receipt.t()],
+          state_root: binary(),
+          receipts_root: binary(),
+          transactions_root: binary(),
+          logs_bloom: Bloom.t(),
+          gas_used: non_neg_integer()
+        }
+
+  defstruct [
+    :post_state_db,
+    :receipts,
+    :state_root,
+    :receipts_root,
+    :transactions_root,
+    :logs_bloom,
+    :gas_used
+  ]
+end

--- a/test/block/processor_test.exs
+++ b/test/block/processor_test.exs
@@ -1,0 +1,369 @@
+defmodule EEVM.Block.ProcessorTest do
+  use ExUnit.Case, async: true
+
+  alias EEVM.Block.{Header, Processor, Receipt}
+  alias EEVM.{Bloom, BlockResult, Database, StateRoot}
+  alias EEVM.Database.InMemory
+  alias EEVM.MPT.Trie
+
+  # ---------------------------------------------------------------------------
+  # Test doubles
+  # ---------------------------------------------------------------------------
+
+  # A plain-map "transaction" carrying whatever fields the inline executor
+  # needs. Everything uses `gas_limit` because the processor reads it off
+  # every tx to validate against the header.
+  defp tx(fields), do: Enum.into(fields, %{})
+
+  # Tiny encoder that round-trips the map's `:id` to a deterministic binary.
+  # We only need *some* encoder for the transactions-root computation;
+  # tests don't care that it's RLP-compatible with real envelopes.
+  defp tx_encoder, do: fn %{id: id} -> <<id::unsigned-big-256>> end
+
+  # Successful executor that bumps `target`'s balance by `value`. Each tx
+  # may carry `:value`, `:target`, `:gas_used`, `:logs`, `:status`. The db
+  # is mutated by writing the nonce of the `:target` so the state root
+  # changes when `:target` is set, and is unchanged otherwise.
+  defp mutating_executor do
+    fn tx, _block_ctx, db ->
+      gas_used = Map.get(tx, :gas_used, 21_000)
+      status = Map.get(tx, :status, 1)
+      logs = Map.get(tx, :logs, [])
+
+      new_db =
+        case Map.fetch(tx, :mutate) do
+          {:ok, {address, balance}} -> Database.set_balance(db, address, balance)
+          :error -> db
+        end
+
+      {:ok, %{status: status, gas_used: gas_used, logs: logs, db: new_db}}
+    end
+  end
+
+  defp noop_header(overrides \\ []) do
+    Header.new([gas_limit: 30_000_000] ++ overrides)
+  end
+
+  defp run(header, transactions, db, extra_opts \\ []) do
+    Processor.process_block(
+      header,
+      transactions,
+      db,
+      [tx_executor: mutating_executor(), tx_encoder: tx_encoder()] ++ extra_opts
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # Empty block
+  # ---------------------------------------------------------------------------
+
+  describe "empty block" do
+    test "runs system calls in order and returns empty-trie commitments" do
+      db = InMemory.new()
+      header = noop_header()
+
+      {:ok, call_log} = Agent.start_link(fn -> [] end)
+
+      hook_a = fn db_in, _ctx ->
+        Agent.update(call_log, fn xs -> [:a | xs] end)
+        Database.set_balance(db_in, 0xA, 1)
+      end
+
+      hook_b = fn db_in, _ctx ->
+        Agent.update(call_log, fn xs -> [:b | xs] end)
+        Database.set_balance(db_in, 0xB, 2)
+      end
+
+      {:ok, %BlockResult{} = result} =
+        run(header, [], db, system_calls: [hook_a, hook_b])
+
+      assert Agent.get(call_log, &Enum.reverse(&1)) == [:a, :b]
+      assert Database.get_balance(result.post_state_db, 0xA) == 1
+      assert Database.get_balance(result.post_state_db, 0xB) == 2
+
+      # No transactions → receipts/transactions roots are the empty-trie hash.
+      empty_root = Trie.root_hash([])
+      assert result.receipts_root == empty_root
+      assert result.transactions_root == empty_root
+      assert result.logs_bloom == Bloom.empty()
+      assert result.receipts == []
+      assert result.gas_used == 0
+
+      assert result.state_root == StateRoot.compute_state_root(result.post_state_db)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Single transaction block
+  # ---------------------------------------------------------------------------
+
+  describe "single transaction block" do
+    test "invokes the executor once and records a matching receipt" do
+      db = InMemory.new()
+      header = noop_header()
+
+      {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+      counting_executor = fn _tx, _ctx, db_in ->
+        Agent.update(calls, &(&1 + 1))
+        {:ok, %{status: 1, gas_used: 21_000, logs: [], db: db_in}}
+      end
+
+      {:ok, result} =
+        Processor.process_block(
+          header,
+          [tx(id: 1, gas_limit: 100_000)],
+          db,
+          tx_executor: counting_executor,
+          tx_encoder: tx_encoder()
+        )
+
+      assert Agent.get(calls, & &1) == 1
+      assert length(result.receipts) == 1
+
+      [%Receipt{cumulative_gas_used: cumulative}] = result.receipts
+      assert cumulative == 21_000
+      assert result.gas_used == 21_000
+
+      # receipts_root with a single receipt should be non-empty and match a
+      # direct Trie.root_hash of the same encoding shape.
+      assert result.receipts_root != Trie.root_hash([])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Multi-transaction block
+  # ---------------------------------------------------------------------------
+
+  describe "multi transaction block" do
+    test "cumulative_gas_used accumulates in order across receipts" do
+      db = InMemory.new()
+      header = noop_header()
+
+      txs = [
+        tx(id: 1, gas_limit: 100_000, gas_used: 21_000),
+        tx(id: 2, gas_limit: 100_000, gas_used: 30_000),
+        tx(id: 3, gas_limit: 100_000, gas_used: 40_000)
+      ]
+
+      {:ok, result} = run(header, txs, db)
+
+      assert Enum.map(result.receipts, & &1.cumulative_gas_used) == [21_000, 51_000, 91_000]
+      assert result.gas_used == 91_000
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Block gas limit exceeded
+  # ---------------------------------------------------------------------------
+
+  describe "block gas limit enforcement" do
+    test "rejects the block when sum(tx.gas_limit) > header.gas_limit" do
+      db = InMemory.new()
+      header = noop_header(gas_limit: 50_000)
+
+      txs = [
+        tx(id: 1, gas_limit: 30_000),
+        tx(id: 2, gas_limit: 30_000)
+      ]
+
+      assert {:error, :block_gas_limit_exceeded} = run(header, txs, db)
+    end
+
+    test "accepts sum equal to the header gas limit" do
+      db = InMemory.new()
+      header = noop_header(gas_limit: 60_000)
+
+      txs = [
+        tx(id: 1, gas_limit: 30_000, gas_used: 30_000),
+        tx(id: 2, gas_limit: 30_000, gas_used: 30_000)
+      ]
+
+      assert {:ok, %BlockResult{gas_used: 60_000}} = run(header, txs, db)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # System calls run BEFORE transactions
+  # ---------------------------------------------------------------------------
+
+  describe "system call ordering" do
+    test "system calls execute before transactions even with zero txs" do
+      db = InMemory.new()
+      header = noop_header()
+
+      seed_balance = fn db_in, _ctx -> Database.set_balance(db_in, 0xBEEF, 123) end
+
+      {:ok, result} = run(header, [], db, system_calls: [seed_balance])
+
+      assert Database.get_balance(result.post_state_db, 0xBEEF) == 123
+    end
+
+    test "transactions see the post-system-call database" do
+      db = InMemory.new()
+      header = noop_header()
+
+      seed = fn db_in, _ctx -> Database.set_balance(db_in, 0xBEEF, 1_000) end
+
+      observing_executor = fn _tx, _ctx, db_in ->
+        # The executor observes the balance planted by the system call and
+        # forwards it into the tx_result's db so we can assert on it.
+        observed = Database.get_balance(db_in, 0xBEEF)
+        mutated_db = Database.set_balance(db_in, 0xCAFE, observed)
+        {:ok, %{status: 1, gas_used: 21_000, logs: [], db: mutated_db}}
+      end
+
+      {:ok, result} =
+        Processor.process_block(
+          header,
+          [tx(id: 1, gas_limit: 100_000)],
+          db,
+          tx_executor: observing_executor,
+          tx_encoder: tx_encoder(),
+          system_calls: [seed]
+        )
+
+      assert Database.get_balance(result.post_state_db, 0xCAFE) == 1_000
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # State root behaviour
+  # ---------------------------------------------------------------------------
+
+  describe "state root" do
+    test "changes when a transaction mutates state" do
+      db = InMemory.new()
+      header = noop_header()
+      pre_root = StateRoot.compute_state_root(db)
+
+      {:ok, result} =
+        run(header, [tx(id: 1, gas_limit: 100_000, mutate: {0x42, 9_999})], db)
+
+      assert result.state_root != pre_root
+      assert result.state_root == StateRoot.compute_state_root(result.post_state_db)
+    end
+
+    test "stays stable when no transaction mutates state" do
+      db = InMemory.new()
+      header = noop_header()
+      pre_root = StateRoot.compute_state_root(db)
+
+      {:ok, result} = run(header, [tx(id: 1, gas_limit: 100_000)], db)
+
+      assert result.state_root == pre_root
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Logs bloom aggregation
+  # ---------------------------------------------------------------------------
+
+  describe "logs bloom" do
+    test "aggregates every receipt's bloom into the block bloom" do
+      db = InMemory.new()
+      header = noop_header()
+
+      log_a = %{address: 0x1111, topics: [0xAAA], data: <<>>}
+      log_b = %{address: 0x2222, topics: [0xBBB, 0xCCC], data: <<0x01>>}
+
+      txs = [
+        tx(id: 1, gas_limit: 100_000, logs: [log_a]),
+        tx(id: 2, gas_limit: 100_000, logs: [log_b])
+      ]
+
+      {:ok, result} = run(header, txs, db)
+
+      # The block bloom should carry every address/topic from every receipt.
+      assert Bloom.contains?(result.logs_bloom, <<0x1111::unsigned-big-160>>)
+      assert Bloom.contains?(result.logs_bloom, <<0xAAA::unsigned-big-256>>)
+      assert Bloom.contains?(result.logs_bloom, <<0x2222::unsigned-big-160>>)
+      assert Bloom.contains?(result.logs_bloom, <<0xBBB::unsigned-big-256>>)
+      assert Bloom.contains?(result.logs_bloom, <<0xCCC::unsigned-big-256>>)
+
+      # And each receipt's own bloom should only carry its own logs.
+      [r1, r2] = result.receipts
+      assert r1.logs_bloom == Bloom.from_logs([log_a])
+      assert r2.logs_bloom == Bloom.from_logs([log_b])
+
+      assert result.logs_bloom == Bloom.merge(r1.logs_bloom, r2.logs_bloom)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Per-transaction failure
+  # ---------------------------------------------------------------------------
+
+  describe "per-transaction failure" do
+    test "halts on first executor error and reports the offending index" do
+      db = InMemory.new()
+      header = noop_header()
+
+      failing_executor = fn tx, _ctx, db_in ->
+        case Map.get(tx, :id) do
+          2 ->
+            {:error, :nonce_mismatch}
+
+          _ ->
+            {:ok,
+             %{
+               status: 1,
+               gas_used: 21_000,
+               logs: [],
+               db: Database.set_balance(db_in, Map.get(tx, :id), 1)
+             }}
+        end
+      end
+
+      txs = [
+        tx(id: 1, gas_limit: 100_000),
+        tx(id: 2, gas_limit: 100_000),
+        tx(id: 3, gas_limit: 100_000)
+      ]
+
+      result =
+        Processor.process_block(
+          header,
+          txs,
+          db,
+          tx_executor: failing_executor,
+          tx_encoder: tx_encoder()
+        )
+
+      assert result == {:error, {:tx_failed, 1, :nonce_mismatch}}
+    end
+
+    test "reports index 0 when the very first transaction fails" do
+      db = InMemory.new()
+      header = noop_header()
+
+      executor = fn _tx, _ctx, _db -> {:error, :insufficient_balance} end
+
+      assert Processor.process_block(
+               header,
+               [tx(id: 1, gas_limit: 100_000)],
+               db,
+               tx_executor: executor,
+               tx_encoder: tx_encoder()
+             ) == {:error, {:tx_failed, 0, :insufficient_balance}}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Option validation
+  # ---------------------------------------------------------------------------
+
+  describe "option validation" do
+    test "raises when :tx_executor is missing" do
+      assert_raise ArgumentError, ~r/:tx_executor is required/, fn ->
+        Processor.process_block(noop_header(), [], InMemory.new(), [])
+      end
+    end
+
+    test "raises when :tx_executor is not a 3-arity function" do
+      assert_raise ArgumentError, ~r/must be a 3-arity function/, fn ->
+        Processor.process_block(noop_header(), [], InMemory.new(), tx_executor: :nope)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `EEVM.Block.Processor.process_block/4`, which runs a block end-to-end: pre-flight gas-limit check → system-call hooks → transaction fold with cumulative-gas tracking → root/bloom commitments.
- Introduces value structs `EEVM.Block.Header`, `EEVM.Block.Receipt`, and `EEVM.BlockResult` for the inputs and outputs.
- Computes `state_root`, `receipts_root`, `transactions_root`, `logs_bloom`, and total `gas_used` to match what an external verifier would check against the advertised header.

## Notes
- The transaction executor (#83) and system-call hooks (#81 / #82) are **dependency-injected** rather than aliased, so this PR is independently mergeable. Callers pass `:tx_executor` (3-arity fn) and an optional `:system_calls` list. A follow-up will wire in real defaults once those PRs land.
- First `{:error, reason}` from the executor halts the fold and surfaces `{:error, {:tx_failed, index, reason}}` — no optimistic rollback.
- Receipt encoding follows the Byzantium-and-later layout `[status, cumulativeGasUsed, bloom, logs]`.

Closes #86.

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict`
- [x] `mix test` (571 tests, 0 failures; 14 new in `test/block/processor_test.exs`)
- [ ] Wire real `:tx_executor` and system-call hooks once #83 / #81 / #82 merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)