### PR TITLE
feat: add end-to-end transaction execution pipeline

### DIFF
--- a/lib/eevm/transaction/executor.ex
+++ b/lib/eevm/transaction/executor.ex
@@ -1,0 +1,565 @@
+defmodule EEVM.Transaction.Executor do
+  @moduledoc """
+  End-to-end transaction execution pipeline.
+
+  ## EVM Concepts
+
+  A signed transaction is not a single operation — it is a sequence of well-defined
+  steps the client must perform against current world state. This module implements
+  those steps in order, using the primitives already provided by the rest of the
+  codebase:
+
+  1. **Decode** — wire-format RLP bytes are turned into a typed `EEVM.Transaction`
+     envelope struct. Callers that already have a struct can pass it directly.
+  2. **Recover sender** — secp256k1 ecrecover on the typed signing hash yields
+     the transaction originator.
+  3. **Validate** — intrinsic gas, nonce, balance, EOA sender, EIP-1559 fee
+     constraints, and blob/initcode size rules are checked via
+     `EEVM.Transaction.Validator`.
+  4. **Charge upfront gas** — `gas_limit * effective_gas_price + value` must fit
+     in the sender's balance. For EIP-1559 the up-front check uses
+     `max_fee_per_gas`, while the actual price charged is
+     `min(max_fee_per_gas, base_fee + max_priority_fee_per_gas)`.
+  5. **Calculate intrinsic gas** — `EEVM.Transaction.IntrinsicGas.calculate/1`
+     returns the base 21,000 + per-byte + access-list + initcode components.
+     The gas available to the EVM is `tx.gas_limit - intrinsic`.
+  6. **Set up context** — `EEVM.Context.Transaction`, `Block`, and `Contract` are
+     populated so opcode implementations (ORIGIN, CALLER, CALLVALUE, CHAINID, …)
+     read consistent values.
+  7. **Pre-warm access set** — EIP-2929/EIP-3651 pre-warming is done by
+     `EEVM.MachineState.new/2`; additional access-list entries are merged into
+     `accessed_addresses` and `accessed_storage_keys` before execution.
+  8. **Execute** — a normal call hands off to `EEVM.Executor.run/2`. A contract
+     deployment (`to == nil`) runs the initcode, deploys the returned runtime
+     code at a CREATE-derived address, and charges code deposit cost.
+  9. **Apply refund** — `min(refund, gas_used / 5)` is added back; already
+     performed by `EEVM.Executor.run/2`'s `apply_refund/2` helper.
+  10. **Settle fees** — the sender is debited `gas_used * effective_gas_price`;
+      the coinbase is credited `gas_used * (effective_gas_price - base_fee)`.
+  11. **Build receipt** — status, cumulative gas, logs, logs bloom.
+
+  ## Elixir Learning Notes
+
+  - The pipeline is written as a `with` chain — each step returns `{:ok, …}`
+    or `{:error, reason}`, and the chain short-circuits on the first failure.
+  - The sender is represented two ways: as a 20-byte binary (from the wire
+    and from `Signer.recover_sender/2`) and as an integer (inside the
+    `EEVM.Context.Transaction` struct and the `EEVM.Database` key space).
+    A single `decode_address/1` helper does the conversion.
+  - Contract creation derives the new address via `keccak(rlp([sender, nonce]))`
+    — the same algorithm used by `CREATE` inside the EVM, kept separate here
+    so the top-level pipeline does not depend on the opcode module's internals.
+  """
+
+  alias EEVM.{Bloom, Config, Database, HardforkConfig, MachineState, TransactionResult}
+  alias EEVM.Context.{Block, Contract, Transaction}
+
+  alias EEVM.Transaction.{
+    AccessList,
+    Blob,
+    Envelope,
+    FeeMarket,
+    IntrinsicGas,
+    Legacy,
+    SetCode,
+    Signer,
+    Validator
+  }
+
+  @type wire_tx ::
+          Legacy.t() | AccessList.t() | FeeMarket.t() | Blob.t() | SetCode.t() | binary()
+
+  @type opts :: [
+          hardfork: HardforkConfig.spec_id(),
+          chain_id: non_neg_integer(),
+          config: Config.t()
+        ]
+
+  @default_chain_id 1
+  @default_hardfork :cancun
+  @max_code_size 24_576
+  @code_deposit_gas_per_byte 200
+
+  @doc """
+  Executes a single transaction end-to-end.
+
+  `tx_or_bytes` may be either raw wire bytes (legacy RLP or a typed envelope
+  prefix + RLP) or one of the typed `EEVM.Transaction.*` structs.
+
+  ## Options
+
+  - `:chain_id` — chain id used when recovering the sender (default: `1`).
+  - `:hardfork` — hardfork spec id governing gas rules and EIP activation
+    (default: `:cancun`).
+  - `:config` — fully assembled `EEVM.Config` to use instead of deriving one
+    from `:hardfork`. Takes precedence when both are provided.
+
+  ## Returns
+
+  - `{:ok, %EEVM.TransactionResult{}}` on any transaction that made it past
+    validation — including reverted ones. Inspect `result.status` to tell
+    success from revert.
+  - `{:error, reason}` when decoding, sender recovery, validation, or upfront
+    balance charging fail. The database is returned unchanged to the caller
+    in this case (the `TransactionResult.post_state_db` is not built).
+  """
+  @spec execute(wire_tx(), Block.t(), Database.t(), opts()) ::
+          {:ok, TransactionResult.t()} | {:error, atom()}
+  def execute(tx_or_bytes, %Block{} = block, %Database{} = db, opts \\ []) do
+    chain_id = Keyword.get(opts, :chain_id, @default_chain_id)
+    config = resolve_config(opts)
+
+    with {:ok, wire_tx} <- ensure_decoded(tx_or_bytes),
+         {:ok, sender_bytes} <- Signer.recover_sender(wire_tx, chain_id),
+         {:ok, tx_ctx} <- build_tx_context(wire_tx, sender_bytes),
+         :ok <- Validator.validate(tx_ctx, db, block, config.hardfork),
+         {:ok, db_after_upfront} <- charge_upfront(db, tx_ctx, block) do
+      run_and_finalize(tx_ctx, sender_bytes, db_after_upfront, block, config)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Decoding
+  # ---------------------------------------------------------------------------
+
+  defp ensure_decoded(%Legacy{} = tx), do: {:ok, tx}
+  defp ensure_decoded(%AccessList{} = tx), do: {:ok, tx}
+  defp ensure_decoded(%FeeMarket{} = tx), do: {:ok, tx}
+  defp ensure_decoded(%Blob{} = tx), do: {:ok, tx}
+  defp ensure_decoded(%SetCode{} = tx), do: {:ok, tx}
+  defp ensure_decoded(bytes) when is_binary(bytes), do: Envelope.decode(bytes)
+  defp ensure_decoded(_), do: {:error, :invalid_transaction_input}
+
+  defp resolve_config(opts) do
+    case Keyword.fetch(opts, :config) do
+      {:ok, %Config{} = config} ->
+        config
+
+      _ ->
+        Config.new(Keyword.get(opts, :hardfork, @default_hardfork))
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Wire tx -> Context.Transaction
+  # ---------------------------------------------------------------------------
+
+  defp build_tx_context(%Legacy{} = tx, sender_bytes) do
+    {:ok,
+     Transaction.new(
+       origin: decode_address(sender_bytes),
+       nonce: tx.nonce,
+       gas_limit: tx.gas_limit,
+       to: optional_address(tx.to),
+       value: tx.value,
+       data: tx.data,
+       gasprice: tx.gas_price,
+       max_fee_per_gas: tx.gas_price,
+       max_priority_fee_per_gas: tx.gas_price,
+       access_list: [],
+       blob_hashes: [],
+       max_fee_per_blob_gas: 0,
+       type: :legacy
+     )}
+  end
+
+  defp build_tx_context(%AccessList{} = tx, sender_bytes) do
+    {:ok,
+     Transaction.new(
+       origin: decode_address(sender_bytes),
+       nonce: tx.nonce,
+       gas_limit: tx.gas_limit,
+       to: optional_address(tx.to),
+       value: tx.value,
+       data: tx.data,
+       gasprice: tx.gas_price,
+       max_fee_per_gas: tx.gas_price,
+       max_priority_fee_per_gas: tx.gas_price,
+       access_list: decode_access_list(tx.access_list),
+       blob_hashes: [],
+       max_fee_per_blob_gas: 0,
+       type: :eip2930
+     )}
+  end
+
+  defp build_tx_context(%FeeMarket{} = tx, sender_bytes) do
+    {:ok,
+     Transaction.new(
+       origin: decode_address(sender_bytes),
+       nonce: tx.nonce,
+       gas_limit: tx.gas_limit,
+       to: optional_address(tx.to),
+       value: tx.value,
+       data: tx.data,
+       gasprice: 0,
+       max_fee_per_gas: tx.max_fee_per_gas,
+       max_priority_fee_per_gas: tx.max_priority_fee_per_gas,
+       access_list: decode_access_list(tx.access_list),
+       blob_hashes: [],
+       max_fee_per_blob_gas: 0,
+       type: :eip1559
+     )}
+  end
+
+  defp build_tx_context(%Blob{} = tx, sender_bytes) do
+    {:ok,
+     Transaction.new(
+       origin: decode_address(sender_bytes),
+       nonce: tx.nonce,
+       gas_limit: tx.gas_limit,
+       to: optional_address(tx.to),
+       value: tx.value,
+       data: tx.data,
+       gasprice: 0,
+       max_fee_per_gas: tx.max_fee_per_gas,
+       max_priority_fee_per_gas: tx.max_priority_fee_per_gas,
+       access_list: decode_access_list(tx.access_list),
+       blob_hashes: Enum.map(tx.blob_versioned_hashes, &:binary.decode_unsigned/1),
+       max_fee_per_blob_gas: tx.max_fee_per_blob_gas,
+       type: :eip4844
+     )}
+  end
+
+  defp build_tx_context(%SetCode{}, _sender_bytes), do: {:error, :set_code_not_supported}
+
+  defp optional_address(nil), do: nil
+  defp optional_address(<<>>), do: nil
+
+  defp optional_address(bytes) when is_binary(bytes) and byte_size(bytes) == 20,
+    do: :binary.decode_unsigned(bytes)
+
+  defp decode_address(bytes) when is_binary(bytes) and byte_size(bytes) == 20,
+    do: :binary.decode_unsigned(bytes)
+
+  defp decode_access_list(access_list) do
+    Enum.map(access_list, fn {address, slots} ->
+      {:binary.decode_unsigned(address), Enum.map(slots, &:binary.decode_unsigned/1)}
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Upfront balance charge (step 4)
+  # ---------------------------------------------------------------------------
+
+  # Validate the sender can pay `gas_limit * max_price + value`, then debit
+  # the *gas* portion only. `value` is moved separately by `transfer_value/4`
+  # at the moment the call frame is set up, so we must not deduct it twice.
+  defp charge_upfront(%Database{} = db, %Transaction{} = tx, %Block{} = block) do
+    sender_balance = Database.get_balance(db, tx.origin)
+    gas_charge = gas_upfront(tx)
+
+    cond do
+      sender_balance < gas_charge + tx.value ->
+        {:error, :insufficient_balance}
+
+      effective_gas_price(tx, block) < block.basefee ->
+        {:error, :effective_gas_price_below_basefee}
+
+      true ->
+        debited = Database.set_balance(db, tx.origin, sender_balance - gas_charge)
+        {:ok, debited}
+    end
+  end
+
+  defp gas_upfront(%Transaction{type: type} = tx) when type in [:eip1559, :eip4844] do
+    tx.gas_limit * tx.max_fee_per_gas
+  end
+
+  defp gas_upfront(%Transaction{} = tx), do: tx.gas_limit * tx.gasprice
+
+  defp effective_gas_price(%Transaction{type: type} = tx, %Block{} = block)
+       when type in [:eip1559, :eip4844] do
+    min(tx.max_fee_per_gas, block.basefee + tx.max_priority_fee_per_gas)
+  end
+
+  defp effective_gas_price(%Transaction{} = tx, %Block{}), do: tx.gasprice
+
+  # ---------------------------------------------------------------------------
+  # Execution + finalization (steps 5–11)
+  # ---------------------------------------------------------------------------
+
+  defp run_and_finalize(
+         %Transaction{} = tx,
+         sender_bytes,
+         %Database{} = db_after_upfront,
+         %Block{} = block,
+         %Config{} = config
+       ) do
+    intrinsic = IntrinsicGas.calculate(tx)
+
+    if tx.gas_limit < intrinsic do
+      {:error, :intrinsic_gas_too_low}
+    else
+      execution_gas = tx.gas_limit - intrinsic
+      db_nonce_bumped = Database.increment_nonce(db_after_upfront, tx.origin)
+
+      {final_state, contract_address} =
+        execute_top_level(tx, db_nonce_bumped, block, config, execution_gas)
+
+      gas_used = tx.gas_limit - final_state.gas
+      effective_price = effective_gas_price(tx, block)
+
+      settled_db = settle_state(final_state, db_nonce_bumped, tx, gas_used, effective_price)
+      coinbase_credited_db = credit_coinbase(settled_db, block, tx, gas_used, effective_price)
+
+      status = result_status(final_state.status)
+
+      logs = if status == :success, do: final_state.logs, else: []
+      logs_bloom = Bloom.from_logs(logs)
+      receipt_status = if status == :success, do: 1, else: 0
+
+      receipt = %{
+        status: receipt_status,
+        cumulative_gas_used: gas_used,
+        logs_bloom: logs_bloom,
+        logs: logs
+      }
+
+      gas_refunded = max(final_state.gas, 0)
+
+      {:ok,
+       %TransactionResult{
+         status: status,
+         gas_used: gas_used,
+         gas_refunded: gas_refunded,
+         sender: decode_address(sender_bytes),
+         logs: logs,
+         logs_bloom: logs_bloom,
+         receipt: receipt,
+         post_state_db: coinbase_credited_db,
+         return_data: if(status == :success, do: final_state.return_data, else: <<>>),
+         contract_address: if(status == :success, do: contract_address, else: nil)
+       }}
+    end
+  end
+
+  # Execute a call-like transaction (step 8, call path).
+  defp execute_top_level(%Transaction{to: to} = tx, db, block, config, execution_gas)
+       when is_integer(to) do
+    db_after_value = transfer_value(db, tx.origin, to, tx.value)
+    code = Database.get_code(db_after_value, to)
+
+    contract_ctx =
+      Contract.new(
+        address: to,
+        caller: tx.origin,
+        callvalue: tx.value,
+        calldata: tx.data
+      )
+
+    accessed_addresses = initial_accessed_addresses(tx, config, contract_ctx, block)
+    accessed_storage_keys = initial_accessed_storage_keys(tx)
+
+    final_state =
+      EEVM.execute(code,
+        gas: execution_gas,
+        db: db_after_value,
+        tx: tx,
+        block: block,
+        contract: contract_ctx,
+        config: config,
+        accessed_addresses: accessed_addresses,
+        accessed_storage_keys: accessed_storage_keys
+      )
+
+    {final_state, nil}
+  end
+
+  # Execute a CREATE-style top-level transaction (step 8, create path).
+  defp execute_top_level(%Transaction{to: nil} = tx, db, block, config, execution_gas) do
+    creator = tx.origin
+    # The nonce bump has already happened; derive the contract address from the
+    # nonce value *before* that bump (the sender's pre-tx nonce).
+    pre_nonce = max(Database.get_nonce(db, creator) - 1, 0)
+    new_address = derive_create_address(creator, pre_nonce)
+
+    db_after_value = transfer_value(db, creator, new_address, tx.value)
+
+    contract_ctx =
+      Contract.new(
+        address: new_address,
+        caller: creator,
+        callvalue: tx.value,
+        calldata: <<>>
+      )
+
+    accessed_addresses = initial_accessed_addresses(tx, config, contract_ctx, block)
+    accessed_storage_keys = initial_accessed_storage_keys(tx)
+
+    final_state =
+      EEVM.execute(tx.data,
+        gas: execution_gas,
+        db: db_after_value,
+        tx: tx,
+        block: block,
+        contract: contract_ctx,
+        config: config,
+        accessed_addresses: accessed_addresses,
+        accessed_storage_keys: accessed_storage_keys
+      )
+
+    case deploy_runtime_code(final_state, new_address) do
+      {:ok, deployed_state} -> {deployed_state, new_address}
+      {:error, deployed_state} -> {deployed_state, nil}
+    end
+  end
+
+  defp deploy_runtime_code(%MachineState{status: :stopped} = state, new_address) do
+    runtime_code = state.return_data
+    size = byte_size(runtime_code)
+    deposit_cost = size * @code_deposit_gas_per_byte
+
+    cond do
+      size > @max_code_size ->
+        {:error, %{state | gas: 0, status: :reverted}}
+
+      state.gas < deposit_cost ->
+        {:error, %{state | gas: 0, status: :reverted}}
+
+      size > 0 and :binary.first(runtime_code) == 0xEF and
+          HardforkConfig.enabled?(state.config.hardfork, :eip_3541) ->
+        {:error, %{state | gas: 0, status: :reverted}}
+
+      true ->
+        updated_db =
+          state.db
+          |> Database.put_code(new_address, runtime_code)
+          |> Database.set_nonce(new_address, 1)
+
+        {:ok, %{state | db: updated_db, gas: state.gas - deposit_cost}}
+    end
+  end
+
+  defp deploy_runtime_code(state, _new_address), do: {:error, state}
+
+  defp transfer_value(%Database{} = db, _from, _to, 0), do: db
+
+  defp transfer_value(%Database{} = db, from, to, value) do
+    case Database.transfer(db, from, to, value) do
+      {:ok, new_db} -> new_db
+      # Upfront charge already ensured the sender has balance for `value`;
+      # hit this branch only if an external database rejects the transfer.
+      {:error, :insufficient_balance} -> db
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Access list pre-warming
+  # ---------------------------------------------------------------------------
+
+  defp initial_accessed_addresses(tx, config, contract_ctx, block) do
+    base =
+      MapSet.new()
+      |> MapSet.put(contract_ctx.address)
+      |> MapSet.put(contract_ctx.caller)
+      |> MapSet.put(tx.origin)
+      |> MapSet.put(block.coinbase)
+      |> then(fn set ->
+        Enum.reduce(EEVM.Precompiles.precompile_addresses(config), set, &MapSet.put(&2, &1))
+      end)
+
+    Enum.reduce(tx.access_list, base, fn {address, _slots}, acc ->
+      MapSet.put(acc, address)
+    end)
+  end
+
+  defp initial_accessed_storage_keys(tx) do
+    Enum.reduce(tx.access_list, MapSet.new(), fn {address, slots}, acc ->
+      Enum.reduce(slots, acc, fn slot, inner -> MapSet.put(inner, {address, slot}) end)
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # State settlement (steps 9–10)
+  # ---------------------------------------------------------------------------
+
+  # The sender was debited `gas_limit * max_price` upfront. They actually owe
+  # `gas_used * effective_price`. Refund the difference to the appropriate db:
+  #
+  # - On success, the executor's db already reflects every side effect, so we
+  #   credit there.
+  # - On revert / out-of-gas / invalid, EVM-side mutations are dropped — we
+  #   credit the post-upfront, post-nonce-bump db instead.
+  #
+  # `effective_price <= max_price`, so this term is always non-negative; for
+  # legacy transactions where max == effective the refund collapses to the
+  # unused-gas refund (`state.gas * gas_price`).
+  defp settle_state(%MachineState{status: status}, db_nonce_bumped, tx, gas_used, effective_price)
+       when status in [:reverted, :invalid, :out_of_gas] or is_tuple(status) do
+    refund_amount = gas_upfront(tx) - gas_used * effective_price
+    credit_sender(db_nonce_bumped, tx.origin, refund_amount)
+  end
+
+  defp settle_state(%MachineState{} = state, _db_nonce_bumped, tx, gas_used, effective_price) do
+    refund_amount = gas_upfront(tx) - gas_used * effective_price
+    credit_sender(state.db, tx.origin, refund_amount)
+  end
+
+  defp credit_coinbase(%Database{} = db, %Block{}, _tx, 0, _price), do: db
+
+  defp credit_coinbase(%Database{} = db, %Block{} = block, %Transaction{} = tx, gas_used, _price) do
+    priority_per_gas = max(effective_gas_price(tx, block) - block.basefee, 0)
+    reward = priority_per_gas * gas_used
+
+    if reward == 0 do
+      db
+    else
+      credit_sender(db, block.coinbase, reward)
+    end
+  end
+
+  defp credit_sender(%Database{} = db, _address, 0), do: db
+
+  defp credit_sender(%Database{} = db, address, amount) do
+    current = Database.get_balance(db, address)
+    Database.set_balance(db, address, current + amount)
+  end
+
+  defp result_status(:stopped), do: :success
+  defp result_status(:reverted), do: :reverted
+  defp result_status(_), do: :reverted
+
+  # ---------------------------------------------------------------------------
+  # CREATE address derivation (keccak(rlp([sender, nonce]))[-20:])
+  # ---------------------------------------------------------------------------
+
+  defp derive_create_address(sender, nonce) do
+    sender_bytes = <<sender::unsigned-big-160>>
+    payload = rlp_encode_list([rlp_encode_bytes(sender_bytes), rlp_encode_integer(nonce)])
+    <<_::binary-size(12), address::unsigned-big-160>> = ExKeccak.hash_256(payload)
+    address
+  end
+
+  defp rlp_encode_integer(0), do: <<0x80>>
+
+  defp rlp_encode_integer(value) when is_integer(value) and value > 0 do
+    value
+    |> :binary.encode_unsigned()
+    |> rlp_encode_bytes()
+  end
+
+  defp rlp_encode_bytes(<<byte>>) when byte < 0x80, do: <<byte>>
+
+  defp rlp_encode_bytes(bytes) do
+    length = byte_size(bytes)
+
+    if length <= 55 do
+      <<0x80 + length, bytes::binary>>
+    else
+      length_bytes = :binary.encode_unsigned(length)
+      <<0xB7 + byte_size(length_bytes), length_bytes::binary, bytes::binary>>
+    end
+  end
+
+  defp rlp_encode_list(items) do
+    payload = IO.iodata_to_binary(items)
+    length = byte_size(payload)
+
+    if length <= 55 do
+      <<0xC0 + length, payload::binary>>
+    else
+      length_bytes = :binary.encode_unsigned(length)
+      <<0xF7 + byte_size(length_bytes), length_bytes::binary, payload::binary>>
+    end
+  end
+end

--- a/lib/eevm/transaction/executor.ex
+++ b/lib/eevm/transaction/executor.ex
@@ -67,7 +67,7 @@ defmodule EEVM.Transaction.Executor do
   }
 
   @type wire_tx ::
-          Legacy.t() | AccessList.t() | FeeMarket.t() | Blob.t() | SetCode.t() | binary()
+          Legacy.t() | AccessList.t() | FeeMarket.t() | Blob.t() | binary()
 
   @type opts :: [
           hardfork: HardforkConfig.spec_id(),
@@ -126,7 +126,7 @@ defmodule EEVM.Transaction.Executor do
   defp ensure_decoded(%AccessList{} = tx), do: {:ok, tx}
   defp ensure_decoded(%FeeMarket{} = tx), do: {:ok, tx}
   defp ensure_decoded(%Blob{} = tx), do: {:ok, tx}
-  defp ensure_decoded(%SetCode{} = tx), do: {:ok, tx}
+  defp ensure_decoded(%SetCode{}), do: {:error, :set_code_not_supported}
   defp ensure_decoded(bytes) when is_binary(bytes), do: Envelope.decode(bytes)
   defp ensure_decoded(_), do: {:error, :invalid_transaction_input}
 
@@ -220,9 +220,6 @@ defmodule EEVM.Transaction.Executor do
      )}
   end
 
-  defp build_tx_context(%SetCode{}, _sender_bytes), do: {:error, :set_code_not_supported}
-
-  defp optional_address(nil), do: nil
   defp optional_address(<<>>), do: nil
 
   defp optional_address(bytes) when is_binary(bytes) and byte_size(bytes) == 20,

--- a/lib/eevm/transaction_result.ex
+++ b/lib/eevm/transaction_result.ex
@@ -1,0 +1,84 @@
+defmodule EEVM.TransactionResult do
+  @moduledoc """
+  Result of running a single transaction through the end-to-end execution pipeline.
+
+  ## EVM Concepts
+
+  Every Ethereum transaction that passes validation produces three things:
+
+  - A **receipt** — status flag, cumulative gas used, logs, and logs bloom —
+    which is what nodes hash into the block's receipts trie. See Yellow Paper
+    §4.3.1.
+  - A **post-state database** — the world state after the transaction's side
+    effects (balance moves, storage writes, nonce bumps, code deployment).
+  - **Return data / contract address** — the raw output of the top-level call,
+    or the newly deployed address for a CREATE transaction (`to == nil`).
+
+  This struct bundles those outputs for consumers (test harnesses, block
+  executors, RPC layers). Transactions that fail validation *before* execution
+  never produce a `TransactionResult` — the pipeline returns `{:error, reason}`
+  in that case and the caller is expected not to apply any state changes.
+
+  ### `status` values
+
+  - `:success` — top-level execution terminated with STOP or RETURN. Receipt
+    status byte is `1`.
+  - `:reverted` — execution halted via REVERT. Receipt status byte is `0` and
+    state changes are rolled back, but the sender is still charged for gas.
+  - `:failed_validation` — used internally by helpers that need to describe
+    a pre-execution failure in the same shape; the pipeline itself returns
+    `{:error, reason}` for these cases rather than a struct.
+
+  ## Elixir Learning Notes
+
+  - Using an atom tag (`:success | :reverted | :failed_validation`) for the
+    result status lets consumers pattern match on success vs. failure without
+    poking at numeric receipt flags.
+  - The `receipt` field is a plain map (not a nested struct) because the
+    Ethereum receipt shape is small and stable — a map keeps construction
+    cheap and keeps serializers flexible.
+  """
+
+  alias EEVM.{Bloom, Database}
+
+  @type status :: :success | :reverted | :failed_validation
+
+  @type log_entry :: %{
+          address: non_neg_integer(),
+          data: binary(),
+          topics: [non_neg_integer()]
+        }
+
+  @type receipt :: %{
+          status: 0 | 1,
+          cumulative_gas_used: non_neg_integer(),
+          logs_bloom: Bloom.t(),
+          logs: [log_entry()]
+        }
+
+  @type t :: %__MODULE__{
+          status: status(),
+          gas_used: non_neg_integer(),
+          gas_refunded: non_neg_integer(),
+          sender: non_neg_integer(),
+          logs: [log_entry()],
+          logs_bloom: Bloom.t(),
+          receipt: receipt(),
+          post_state_db: Database.t(),
+          return_data: binary(),
+          contract_address: non_neg_integer() | nil
+        }
+
+  defstruct [
+    :status,
+    :gas_used,
+    :gas_refunded,
+    :sender,
+    :logs,
+    :logs_bloom,
+    :receipt,
+    :post_state_db,
+    :return_data,
+    :contract_address
+  ]
+end

--- a/test/transaction/executor_test.exs
+++ b/test/transaction/executor_test.exs
@@ -1,0 +1,248 @@
+defmodule EEVM.Transaction.ExecutorTest do
+  use ExUnit.Case, async: true
+
+  alias EEVM.Context.Block
+  alias EEVM.Database
+  alias EEVM.Database.InMemory
+  alias EEVM.Transaction.{Executor, FeeMarket, Legacy, Signer}
+  alias EEVM.TransactionResult
+
+  @priv_key <<
+    120,
+    128,
+    174,
+    201,
+    52,
+    19,
+    241,
+    23,
+    239,
+    20,
+    189,
+    78,
+    109,
+    19,
+    8,
+    117,
+    171,
+    44,
+    125,
+    125,
+    85,
+    160,
+    100,
+    250,
+    195,
+    194,
+    247,
+    189,
+    81,
+    81,
+    99,
+    128
+  >>
+
+  @chain_id 1
+  @coinbase 0xC0F0
+  @recipient 0xB0B
+
+  describe "execute/4 — legacy value transfer" do
+    test "moves value, charges gas, bumps nonce" do
+      sender = sender_address()
+      starting_balance = 1_000_000
+
+      tx = legacy_value_transfer(value: 1_000)
+      db = db_with_sender(balance: starting_balance)
+
+      assert {:ok, %TransactionResult{} = result} = run(tx, db)
+
+      assert result.status == :success
+      assert result.sender == sender
+      assert result.gas_used == 21_000
+      assert result.contract_address == nil
+      assert result.return_data == <<>>
+
+      # 1_000_000 - (21_000 * 1) - 1_000 = 978_000
+      assert Database.get_balance(result.post_state_db, sender) == 978_000
+      assert Database.get_balance(result.post_state_db, @recipient) == 1_000
+      assert Database.get_nonce(result.post_state_db, sender) == 1
+    end
+
+    test "intrinsic gas too low when gas_limit < 21000" do
+      tx = legacy_value_transfer(gas_limit: 20_999)
+
+      assert {:error, :intrinsic_gas_too_low} = run(tx, db_with_sender())
+    end
+
+    test "insufficient balance for upfront cost" do
+      tx = legacy_value_transfer(gas_limit: 21_000, gas_price: 1, value: 100_000_000)
+
+      assert {:error, :insufficient_balance} = run(tx, db_with_sender(balance: 100))
+    end
+
+    test "rejects an unsigned transaction" do
+      unsigned = %Legacy{
+        nonce: 0,
+        gas_price: 1,
+        gas_limit: 21_000,
+        to: <<@recipient::unsigned-big-160>>,
+        value: 0,
+        data: <<>>,
+        v: 27,
+        r: 0,
+        s: 0
+      }
+
+      assert {:error, _} = run(unsigned, db_with_sender())
+    end
+  end
+
+  describe "execute/4 — eip-1559 fee market" do
+    test "uses min(max_fee, basefee + tip), credits coinbase the priority fee" do
+      starting_balance = 10_000_000
+
+      tx =
+        sign_eip1559(%FeeMarket{
+          chain_id: @chain_id,
+          nonce: 0,
+          max_priority_fee_per_gas: 2,
+          max_fee_per_gas: 10,
+          gas_limit: 21_000,
+          to: <<@recipient::unsigned-big-160>>,
+          value: 0,
+          data: <<>>,
+          access_list: [],
+          y_parity: 0,
+          r: 0,
+          s: 0
+        })
+
+      db = db_with_sender(balance: starting_balance)
+      block = simple_block(basefee: 5)
+
+      assert {:ok, %TransactionResult{post_state_db: post_db, gas_used: 21_000}} =
+               run(tx, db, block)
+
+      # effective_price = min(10, 5 + 2) = 7
+      # coinbase reward = (7 - 5) * 21_000 = 42_000
+      assert Database.get_balance(post_db, @coinbase) == 42_000
+      # sender pays gas_used * effective_price = 21_000 * 7 = 147_000
+      assert Database.get_balance(post_db, sender_address()) == starting_balance - 147_000
+    end
+  end
+
+  describe "execute/4 — CREATE" do
+    test "deploys runtime code at CREATE-derived address" do
+      # Initcode that returns a single STOP byte as runtime code:
+      #   PUSH1 0   ; mstore8 value
+      #   PUSH1 0   ; mstore8 offset
+      #   MSTORE8
+      #   PUSH1 1   ; return size
+      #   PUSH1 0   ; return offset
+      #   RETURN
+      initcode = <<0x60, 0x00, 0x60, 0x00, 0x53, 0x60, 0x01, 0x60, 0x00, 0xF3>>
+
+      tx =
+        sign_legacy(
+          %Legacy{
+            nonce: 0,
+            gas_price: 1,
+            gas_limit: 200_000,
+            to: <<>>,
+            value: 0,
+            data: initcode,
+            v: 0,
+            r: 0,
+            s: 0
+          },
+          @chain_id
+        )
+
+      db = db_with_sender(balance: 10_000_000)
+
+      assert {:ok, result} = run(tx, db)
+      assert result.status == :success
+      assert is_integer(result.contract_address)
+      assert Database.get_code(result.post_state_db, result.contract_address) == <<0x00>>
+      assert Database.get_nonce(result.post_state_db, result.contract_address) == 1
+    end
+  end
+
+  describe "execute/4 — REVERT" do
+    test "marks status :reverted and emits no logs" do
+      # PUSH1 0 PUSH1 0 REVERT
+      revert_code = <<0x60, 0x00, 0x60, 0x00, 0xFD>>
+
+      db =
+        db_with_sender(balance: 10_000_000)
+        |> Database.put_code(@recipient, revert_code)
+
+      tx = legacy_value_transfer(gas_limit: 50_000, value: 0)
+
+      assert {:ok, result} = run(tx, db)
+      assert result.status == :reverted
+      assert result.logs == []
+      assert result.return_data == <<>>
+      # Sender's nonce was still bumped despite the revert.
+      assert Database.get_nonce(result.post_state_db, sender_address()) == 1
+    end
+  end
+
+  defp run(tx, db, block \\ simple_block()) do
+    Executor.execute(tx, block, db, chain_id: @chain_id)
+  end
+
+  defp legacy_value_transfer(opts) do
+    sign_legacy(
+      %Legacy{
+        nonce: Keyword.get(opts, :nonce, 0),
+        gas_price: Keyword.get(opts, :gas_price, 1),
+        gas_limit: Keyword.get(opts, :gas_limit, 21_000),
+        to: Keyword.get(opts, :to, <<@recipient::unsigned-big-160>>),
+        value: Keyword.get(opts, :value, 0),
+        data: Keyword.get(opts, :data, <<>>),
+        v: 0,
+        r: 0,
+        s: 0
+      },
+      @chain_id
+    )
+  end
+
+  defp sign_legacy(%Legacy{} = tx, chain_id) do
+    hash = Signer.signing_hash(tx, chain_id)
+
+    {:ok, {<<r::unsigned-big-256, s::unsigned-big-256>>, recovery_id}} =
+      ExSecp256k1.sign_compact(hash, @priv_key)
+
+    %{tx | v: 35 + 2 * chain_id + recovery_id, r: r, s: s}
+  end
+
+  defp sign_eip1559(%FeeMarket{} = tx) do
+    hash = Signer.signing_hash(tx, tx.chain_id)
+
+    {:ok, {<<r::unsigned-big-256, s::unsigned-big-256>>, recovery_id}} =
+      ExSecp256k1.sign_compact(hash, @priv_key)
+
+    %{tx | y_parity: recovery_id, r: r, s: s}
+  end
+
+  defp sender_address do
+    {:ok, <<4, key::binary-size(64)>>} = ExSecp256k1.create_public_key(@priv_key)
+    <<_::binary-size(12), address::binary-size(20)>> = ExKeccak.hash_256(key)
+    :binary.decode_unsigned(address)
+  end
+
+  defp db_with_sender(opts \\ []) do
+    balance = Keyword.get(opts, :balance, 1_000_000_000)
+    nonce = Keyword.get(opts, :nonce, 0)
+
+    InMemory.new(accounts: %{sender_address() => %{balance: balance, nonce: nonce, code: <<>>}})
+  end
+
+  defp simple_block(overrides \\ []) do
+    Block.new(
+      [gaslimit: 30_000_000, basefee: 0, blob_base_fee: 0, coinbase: @coinbase] ++ overrides
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `EEVM.Transaction.Executor.execute/4` — the top-level entry point that turns a signed transaction (wire bytes or typed struct) into a `%EEVM.TransactionResult{}` plus a post-state database. Composes the existing primitives: envelope decode → ecrecover → validator → upfront gas charge → intrinsic gas → context setup → EVM run loop → fee settlement → receipt build.
- Adds `EEVM.TransactionResult` — bundles status / gas / sender / logs / receipt / post-state-db / return data / contract address.

## Notes
- **Upfront charge model:** balance check requires `gas_limit * max_price + value`, but only the *gas* portion is debited up front. The value is moved by the call frame, so it doesn't get double-charged.
- **Refund:** success and revert/oog/invalid all follow `gas_upfront - gas_used * effective_price`. For legacy this is the unused-gas refund; for EIP-1559 it also returns the `(max_fee - effective_price) * gas_used` delta. Revert credits the pre-execution db so EVM-side mutations are dropped while the nonce bump and gas charge stick.
- **Coinbase:** credited the priority fee (`effective_price - basefee`) per gas used.
- **CREATE:** runs initcode, derives the new address via `keccak(rlp([sender, pre_nonce]))`, enforces the 24,576-byte runtime cap and the EIP-3541 `0xEF` prefix rule, and charges code-deposit gas.
- **SetCode (EIP-7702):** intentionally rejected for now — that's tracked separately on its own PR.

Closes #83.

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict`
- [x] `mix test` (564 tests, 0 failures; 7 new in `test/transaction/executor_test.exs` covering the legacy / EIP-1559 / CREATE / REVERT paths plus signature and balance failures)
- [ ] Wire as the default `:tx_executor` in `EEVM.Block.Processor` once #86 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)