### PR TITLE
refactor: extract child-frame merge into EEVM.Interpreter.Journal

### DIFF
--- a/lib/eevm/interpreter/instructions/system/calls.ex
+++ b/lib/eevm/interpreter/instructions/system/calls.ex
@@ -18,7 +18,7 @@ defmodule EEVM.Interpreter.Instructions.System.Calls do
   """
 
   alias EEVM.{Database, Interpreter}
-  alias EEVM.Interpreter.{MachineState, Memory, Stack}
+  alias EEVM.Interpreter.{Journal, MachineState, Memory, Stack}
   alias EEVM.Gas.Dynamic
   alias EEVM.Gas.Memory, as: GasMemory
   alias EEVM.Context.Contract
@@ -254,57 +254,20 @@ defmodule EEVM.Interpreter.Instructions.System.Calls do
               )
 
             child_result = Interpreter.run_loop(child_state)
-            call_succeeded = child_result.status == :stopped
-
-            db_result =
-              if call_succeeded,
-                do: child_result.db,
-                else: state_after_forward.db
-
-            logs_result =
-              if call_succeeded,
-                do: state_after_forward.logs ++ child_result.logs,
-                else: state_after_forward.logs
-
-            accessed_addresses_result =
-              if call_succeeded,
-                do: child_result.accessed_addresses,
-                else: state_after_forward.accessed_addresses
-
-            accessed_storage_keys_result =
-              if call_succeeded,
-                do: child_result.accessed_storage_keys,
-                else: state_after_forward.accessed_storage_keys
-
-            created_addresses_result =
-              if call_succeeded,
-                do: child_result.created_addresses,
-                else: state_after_forward.created_addresses
-
-            touched_addresses_result =
-              if call_succeeded,
-                do: child_result.touched_addresses,
-                else: state_after_forward.touched_addresses
+            merged = Journal.merge_child_result(state_after_forward, child_result)
 
             memory_result =
               write_return_data(memory_after_read, ret_offset, ret_size, child_result.return_data)
 
-            result_flag = if(call_succeeded, do: 1, else: 0)
+            result_flag = if child_result.status == :stopped, do: 1, else: 0
             {:ok, stack_after_call} = Stack.push(state_after_forward.stack, result_flag)
 
             {:ok,
-             state_after_forward
+             merged
              |> Map.put(:stack, stack_after_call)
              |> Map.put(:memory, memory_result)
              |> Map.put(:return_data, child_result.return_data)
-             |> Map.put(:db, db_result)
-             |> Map.put(:logs, logs_result)
-             |> Map.put(:accessed_addresses, accessed_addresses_result)
-             |> Map.put(:accessed_storage_keys, accessed_storage_keys_result)
-             |> Map.put(:created_addresses, created_addresses_result)
-             |> Map.put(:touched_addresses, touched_addresses_result)
              |> Map.put(:gas, state_after_forward.gas + child_result.gas)
-             |> Map.put(:tracer, child_result.tracer)
              |> MachineState.advance_pc()}
           end
 
@@ -411,57 +374,20 @@ defmodule EEVM.Interpreter.Instructions.System.Calls do
               )
 
             child_result = Interpreter.run_loop(child_state)
-            call_succeeded = child_result.status == :stopped
-
-            db_result =
-              if call_succeeded,
-                do: child_result.db,
-                else: state_after_forward.db
-
-            logs_result =
-              if call_succeeded,
-                do: state_after_forward.logs ++ child_result.logs,
-                else: state_after_forward.logs
-
-            accessed_addresses_result =
-              if call_succeeded,
-                do: child_result.accessed_addresses,
-                else: state_after_forward.accessed_addresses
-
-            accessed_storage_keys_result =
-              if call_succeeded,
-                do: child_result.accessed_storage_keys,
-                else: state_after_forward.accessed_storage_keys
-
-            created_addresses_result =
-              if call_succeeded,
-                do: child_result.created_addresses,
-                else: state_after_forward.created_addresses
-
-            touched_addresses_result =
-              if call_succeeded,
-                do: child_result.touched_addresses,
-                else: state_after_forward.touched_addresses
+            merged = Journal.merge_child_result(state_after_forward, child_result)
 
             memory_result =
               write_return_data(memory_after_read, ret_offset, ret_size, child_result.return_data)
 
-            result_flag = if(call_succeeded, do: 1, else: 0)
+            result_flag = if child_result.status == :stopped, do: 1, else: 0
             {:ok, stack_after_call} = Stack.push(state_after_forward.stack, result_flag)
 
             {:ok,
-             state_after_forward
+             merged
              |> Map.put(:stack, stack_after_call)
              |> Map.put(:memory, memory_result)
              |> Map.put(:return_data, child_result.return_data)
-             |> Map.put(:db, db_result)
-             |> Map.put(:logs, logs_result)
-             |> Map.put(:accessed_addresses, accessed_addresses_result)
-             |> Map.put(:accessed_storage_keys, accessed_storage_keys_result)
-             |> Map.put(:created_addresses, created_addresses_result)
-             |> Map.put(:touched_addresses, touched_addresses_result)
              |> Map.put(:gas, state_after_forward.gas + child_result.gas)
-             |> Map.put(:tracer, child_result.tracer)
              |> MachineState.advance_pc()}
           end
 

--- a/lib/eevm/interpreter/instructions/system/creation.ex
+++ b/lib/eevm/interpreter/instructions/system/creation.ex
@@ -21,10 +21,7 @@ defmodule EEVM.Interpreter.Instructions.System.Creation do
   @initcode_word_cost 2
 
   alias EEVM.{Database, HardforkConfig, Interpreter}
-  alias EEVM.Interpreter.{MachineState, Memory, Stack}
-  alias EEVM.Gas.Dynamic
-  alias EEVM.Gas.Memory, as: GasMemory
-  alias EEVM.Context.Contract
+  alias EEVM.Interpreter.{Journal, MachineState, Memory, Stack}
   alias EEVM.Gas.Dynamic
   alias EEVM.Gas.Memory, as: GasMemory
   alias EEVM.Context.Contract
@@ -168,28 +165,20 @@ defmodule EEVM.Interpreter.Instructions.System.Creation do
 
                             {:ok, stack_after_create} = Stack.push(stack, new_address)
 
-                            created_addresses_after =
-                              MapSet.put(child_result.created_addresses, new_address)
+                            merged =
+                              Journal.merge_child_result(state_after_initcode_cost, child_result)
 
                             {:ok,
-                             state_after_initcode_cost
+                             merged
                              |> Map.put(:stack, stack_after_create)
                              |> Map.put(:memory, memory_after_read)
                              |> Map.put(:db, db_after_deploy)
                              |> Map.put(
-                               :logs,
-                               state_after_initcode_cost.logs ++ child_result.logs
+                               :created_addresses,
+                               MapSet.put(merged.created_addresses, new_address)
                              )
-                             |> Map.put(:accessed_addresses, child_result.accessed_addresses)
-                             |> Map.put(
-                               :accessed_storage_keys,
-                               child_result.accessed_storage_keys
-                             )
-                             |> Map.put(:created_addresses, created_addresses_after)
-                             |> Map.put(:touched_addresses, child_result.touched_addresses)
                              |> Map.put(:gas, child_result.gas - deposit_cost)
                              |> Map.put(:return_data, child_result.return_data)
-                             |> Map.put(:tracer, child_result.tracer)
                              |> MachineState.advance_pc()}
                           else
                             create_failed(post_child_fail_state, stack)

--- a/lib/eevm/interpreter/journal.ex
+++ b/lib/eevm/interpreter/journal.ex
@@ -1,0 +1,78 @@
+defmodule EEVM.Interpreter.Journal do
+  @moduledoc """
+  Snapshot/commit semantics for nested EVM call frames.
+
+  ## EVM Concepts
+
+  When a child frame runs (CALL, DELEGATECALL, STATICCALL, CREATE, CREATE2),
+  its mutations to world state become permanent only if the child halts
+  normally (`:stopped`). On revert, out-of-gas, invalid, or any other abnormal
+  halt, those mutations must be discarded — the parent must observe the world
+  state it had before the child was spawned.
+
+  Concretely, six fields of `EEVM.Interpreter.MachineState` participate in
+  this revert behaviour:
+
+  - `db` — the unified world database (accounts + storage)
+  - `logs` — emitted log entries (parent's logs come first, then child's)
+  - `accessed_addresses` — EIP-2929 access list
+  - `accessed_storage_keys` — EIP-2929 access list
+  - `created_addresses` — EIP-6780 set of contracts created in this tx
+  - `touched_addresses` — EIP-161 cleanup set
+
+  The `tracer` field is *not* revertible — trace events accumulate
+  monotonically and are always preserved across child boundaries regardless
+  of the child's outcome.
+
+  ## Why a dedicated module
+
+  Before this module existed, every call/create site re-implemented the
+  conditional "if child succeeded, take child's six fields, else keep
+  parent's" with six per-field local variables and six explicit `Map.put/3`
+  calls. Centralising the merge means: (1) a future revertible field is
+  added in one place, not six; (2) call sites read as "merge child result"
+  rather than as a hand-wired six-field reconciliation.
+
+  ## What this module does NOT cover
+
+  - Stack and memory: those are local to a frame and never propagate child
+    → parent on success or failure.
+  - Gas accounting: the parent's gas refund of `child.gas` happens at the
+    call site, not here, because the math depends on opcode-specific
+    bookkeeping (e.g. CREATE's deposit cost).
+  - The `:db` override in CREATE: the success path replaces `child.db` with
+    a post-deploy db that has the runtime code installed. Call sites apply
+    that override after `merge_child_result/2`.
+  """
+
+  alias EEVM.Interpreter.MachineState
+
+  @doc """
+  Merge the result of a child frame back into its parent.
+
+  - On success (`status: :stopped`): the child's mutations to revertible
+    fields are promoted into the parent. Logs are *appended*, with the
+    parent's existing logs preceding the child's in emission order.
+  - On any other halt: the parent's revertible fields are kept untouched.
+
+  In both cases the child's tracer state is propagated into the parent,
+  because tracing accumulates regardless of execution outcome.
+  """
+  @spec merge_child_result(MachineState.t(), MachineState.t()) :: MachineState.t()
+  def merge_child_result(%MachineState{} = parent, %MachineState{status: :stopped} = child) do
+    %{
+      parent
+      | db: child.db,
+        logs: parent.logs ++ child.logs,
+        accessed_addresses: child.accessed_addresses,
+        accessed_storage_keys: child.accessed_storage_keys,
+        created_addresses: child.created_addresses,
+        touched_addresses: child.touched_addresses,
+        tracer: child.tracer
+    }
+  end
+
+  def merge_child_result(%MachineState{} = parent, %MachineState{} = child) do
+    %{parent | tracer: child.tracer}
+  end
+end

--- a/test/interpreter/journal_test.exs
+++ b/test/interpreter/journal_test.exs
@@ -1,0 +1,123 @@
+defmodule EEVM.Interpreter.JournalTest do
+  use ExUnit.Case, async: true
+
+  alias EEVM.Database.InMemory
+  alias EEVM.Interpreter.{Journal, MachineState}
+
+  describe "merge_child_result/2 — successful child" do
+    test "promotes child's revertible fields onto the parent" do
+      parent = parent_state()
+      parent_db = parent.db
+
+      child_db = InMemory.new() |> seed_account(0xCAFE, 100)
+
+      child = %{
+        parent
+        | status: :stopped,
+          db: child_db,
+          accessed_addresses: MapSet.new([0xAA]),
+          accessed_storage_keys: MapSet.new([{0xAA, 0x01}]),
+          created_addresses: MapSet.new([0xCAFE]),
+          touched_addresses: MapSet.new([0xCAFE])
+      }
+
+      merged = Journal.merge_child_result(parent, child)
+
+      assert merged.db == child_db
+      assert merged.db != parent_db
+      assert merged.accessed_addresses == MapSet.new([0xAA])
+      assert merged.accessed_storage_keys == MapSet.new([{0xAA, 0x01}])
+      assert merged.created_addresses == MapSet.new([0xCAFE])
+      assert merged.touched_addresses == MapSet.new([0xCAFE])
+    end
+
+    test "appends child's logs after parent's, preserving emission order" do
+      parent_log = %{address: 0xAA, topics: [1], data: <<>>}
+      child_log_1 = %{address: 0xBB, topics: [2], data: <<>>}
+      child_log_2 = %{address: 0xCC, topics: [3], data: <<>>}
+
+      parent = %{parent_state() | logs: [parent_log]}
+      child = %{parent | status: :stopped, logs: [child_log_1, child_log_2]}
+
+      merged = Journal.merge_child_result(parent, child)
+
+      assert merged.logs == [parent_log, child_log_1, child_log_2]
+    end
+  end
+
+  describe "merge_child_result/2 — failed child" do
+    for status <- [:reverted, :out_of_gas, :invalid, {:error, :stack_underflow}] do
+      test "with status #{inspect(status)} keeps the parent's revertible fields" do
+        parent = parent_state()
+
+        child_db = InMemory.new() |> seed_account(0xCAFE, 100)
+
+        child = %{
+          parent
+          | status: unquote(Macro.escape(status)),
+            db: child_db,
+            logs: [%{address: 0xBB, topics: [], data: <<>>}],
+            accessed_addresses: MapSet.new([0xAA]),
+            accessed_storage_keys: MapSet.new([{0xAA, 0x01}]),
+            created_addresses: MapSet.new([0xCAFE]),
+            touched_addresses: MapSet.new([0xCAFE])
+        }
+
+        merged = Journal.merge_child_result(parent, child)
+
+        assert merged.db == parent.db
+        assert merged.logs == parent.logs
+        assert merged.accessed_addresses == parent.accessed_addresses
+        assert merged.accessed_storage_keys == parent.accessed_storage_keys
+        assert merged.created_addresses == parent.created_addresses
+        assert merged.touched_addresses == parent.touched_addresses
+      end
+    end
+  end
+
+  describe "merge_child_result/2 — tracer propagation" do
+    test "child's tracer is adopted on success" do
+      parent = %{parent_state() | tracer: :parent_tracer}
+      child = %{parent | status: :stopped, tracer: :child_tracer}
+
+      assert Journal.merge_child_result(parent, child).tracer == :child_tracer
+    end
+
+    test "child's tracer is adopted on failure (tracing accumulates monotonically)" do
+      parent = %{parent_state() | tracer: :parent_tracer}
+      child = %{parent | status: :reverted, tracer: :child_tracer}
+
+      assert Journal.merge_child_result(parent, child).tracer == :child_tracer
+    end
+  end
+
+  describe "merge_child_result/2 — non-revertible fields" do
+    test "parent's stack, memory, pc, gas, refund, contract are not touched on success" do
+      parent = parent_state()
+      child = %{parent | status: :stopped, pc: 999, gas: 999_999, refund: 555}
+
+      merged = Journal.merge_child_result(parent, child)
+
+      assert merged.pc == parent.pc
+      assert merged.gas == parent.gas
+      assert merged.refund == parent.refund
+      assert merged.stack == parent.stack
+      assert merged.memory == parent.memory
+      assert merged.contract == parent.contract
+    end
+  end
+
+  defp parent_state do
+    MachineState.new(<<>>,
+      db: InMemory.new(),
+      accessed_addresses: MapSet.new(),
+      accessed_storage_keys: MapSet.new(),
+      created_addresses: MapSet.new(),
+      touched_addresses: MapSet.new()
+    )
+  end
+
+  defp seed_account(db, address, balance) do
+    EEVM.Database.set_balance(db, address, balance)
+  end
+end


### PR DESCRIPTION
## Summary

Phase 3 of the revm-style refactor (deferred from #114). Extracts the duplicated \"merge child frame result into parent\" pattern from `CALL` / `DELEGATECALL` / `STATICCALL` / `CREATE` / `CREATE2` into a single helper, `EEVM.Interpreter.Journal.merge_child_result/2`.

## Why

Before, three call sites each open-coded the same conditional ladder: if the child halted with `:stopped`, promote the child's six revertible fields (`db`, `logs`, `accessed_addresses`, `accessed_storage_keys`, `created_addresses`, `touched_addresses`) onto the parent; otherwise keep the parent's pre-child values. Adding a future revertible field would have required edits in three places.

After, the revertible-field set lives in one place. Call sites now read as \"merge child result\" rather than as a hand-wired six-field reconciliation. Net change: **-85 lines at the call sites**.

## Why CREATE keeps its failure path bespoke

On `CREATE`/`CREATE2` revert, the Yellow Paper requires the creator's nonce bump to persist even though the rest of the world reverts. That's not generic revert semantics, so the creation failure path stays as-is and only the success path goes through `Journal.merge_child_result/2` (with `db` and `created_addresses` overridden afterward to capture the deploy result and the new contract address).

## Out of scope

- Tracer state is propagated unconditionally (it accumulates monotonically); the helper handles that, but it's not new behaviour.
- The pre-existing `MachineState.{push_frame, pop_frame}` mechanism is orthogonal — it handles the run_loop's revert path for top-level execution, not the inline child-state merge in opcode handlers.

## Test plan

- [x] \`mix format --check-formatted\` clean
- [x] \`mix compile --warnings-as-errors\` clean
- [x] \`mix credo --strict\` clean
- [x] \`mix test\` — 611 tests, 4 doctests, 0 failures (9 new tests cover Journal directly)
- [x] \`mix dialyzer\` clean