### PR TITLE
chore: align with community Elixir style guide

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -12,13 +12,10 @@
       color: true,
       checks: [
         {Credo.Check.Readability.MaxLineLength, max_length: 120},
-        {Credo.Check.Readability.PredicateFunctionNames, false},
         {Credo.Check.Readability.WithSingleClause, false},
-        {Credo.Check.Readability.AliasOrder, false},
         {Credo.Check.Refactor.Nesting, false},
         {Credo.Check.Refactor.CyclomaticComplexity, false},
-        {Credo.Check.Refactor.FunctionArity, false},
-        {Credo.Check.Readability.ModuleDoc, false}
+        {Credo.Check.Refactor.FunctionArity, false}
       ]
     }
   ]

--- a/lib/eevm.ex
+++ b/lib/eevm.ex
@@ -28,9 +28,10 @@ defmodule EEVM do
   - `EEVM.SystemContracts` — EIP-2935 (block hashes) and EIP-4788 (beacon roots)
   """
 
-  alias EEVM.{Interpreter, Tracer}
   alias EEVM.Block.Bloom
+  alias EEVM.Interpreter
   alias EEVM.Interpreter.{MachineState, Stack}
+  alias EEVM.Tracer
 
   @doc """
   Executes EVM bytecode and returns the final machine state.

--- a/lib/eevm/block/processor.ex
+++ b/lib/eevm/block/processor.ex
@@ -62,9 +62,10 @@ defmodule EEVM.Block.Processor do
   """
 
   alias EEVM.Block.{Bloom, Header, Receipt, Result}
-  alias EEVM.{Database, StateRoot}
   alias EEVM.Context.Block, as: BlockCtx
+  alias EEVM.Database
   alias EEVM.MPT.Trie
+  alias EEVM.StateRoot
   alias EEVM.Transaction.Envelope
 
   @type tx_result :: %{

--- a/lib/eevm/config.ex
+++ b/lib/eevm/config.ex
@@ -13,8 +13,7 @@ defmodule EEVM.Config do
           precompiles: %{optional(non_neg_integer()) => module()}
         }
 
-  defstruct hardfork: nil,
-            precompiles: %{}
+  defstruct [:hardfork, precompiles: %{}]
 
   @doc """
   Creates a new config with the given hardfork (default: `:cancun`).

--- a/lib/eevm/handler/post_execution.ex
+++ b/lib/eevm/handler/post_execution.ex
@@ -16,11 +16,12 @@ defmodule EEVM.Handler.PostExecution do
     struct that callers consume.
   """
 
-  alias EEVM.{Database, TransactionResult}
   alias EEVM.Block.Bloom
   alias EEVM.Context.{Block, Transaction}
+  alias EEVM.Database
   alias EEVM.Handler.{PreExecution, Validation}
   alias EEVM.Interpreter.MachineState
+  alias EEVM.TransactionResult
 
   @spec finalize(
           MachineState.t(),

--- a/lib/eevm/handler/pre_execution.ex
+++ b/lib/eevm/handler/pre_execution.ex
@@ -17,8 +17,9 @@ defmodule EEVM.Handler.PreExecution do
   fee-market formula.
   """
 
-  alias EEVM.{Database, Precompiles}
   alias EEVM.Context.{Block, Contract, Transaction}
+  alias EEVM.Database
+  alias EEVM.Precompiles
   alias EEVM.Transaction.IntrinsicGas
 
   @spec charge_upfront(Database.t(), Transaction.t(), Block.t()) ::

--- a/lib/eevm/interpreter.ex
+++ b/lib/eevm/interpreter.ex
@@ -36,12 +36,9 @@ defmodule EEVM.Interpreter do
     their semantics.
   """
 
-  alias EEVM.{HardforkConfig, Tracer}
-  alias EEVM.Interpreter.{MachineState, Memory, Stack}
   alias EEVM.Database
   alias EEVM.Gas.Static
-  alias EEVM.Transaction.IntrinsicGas
-  alias EEVM.Tracer.TraceStep
+  alias EEVM.HardforkConfig
 
   alias EEVM.Interpreter.Instructions.{
     Arithmetic,
@@ -60,6 +57,11 @@ defmodule EEVM.Interpreter do
     System.Creation,
     System.Termination
   }
+
+  alias EEVM.Interpreter.{MachineState, Memory, Stack}
+  alias EEVM.Tracer
+  alias EEVM.Tracer.TraceStep
+  alias EEVM.Transaction.IntrinsicGas
 
   @doc """
   Creates a `MachineState` from bytecode and options, then runs the execution loop.

--- a/lib/eevm/interpreter/call_frame.ex
+++ b/lib/eevm/interpreter/call_frame.ex
@@ -25,8 +25,8 @@ defmodule EEVM.Interpreter.CallFrame do
     needed to suspend and restore execution.
   """
 
-  alias EEVM.Interpreter.{Memory, Stack}
   alias EEVM.Context.Contract
+  alias EEVM.Interpreter.{Memory, Stack}
 
   @type t :: %__MODULE__{
           code: binary(),

--- a/lib/eevm/interpreter/instructions/arithmetic.ex
+++ b/lib/eevm/interpreter/instructions/arithmetic.ex
@@ -32,9 +32,9 @@ defmodule EEVM.Interpreter.Instructions.Arithmetic do
   """
   import Bitwise
 
-  alias EEVM.Interpreter.{MachineState, Stack}
   alias EEVM.Gas.Dynamic
   alias EEVM.Interpreter.Instructions.Helpers
+  alias EEVM.Interpreter.{MachineState, Stack}
 
   @max_uint256 (1 <<< 256) - 1
 

--- a/lib/eevm/interpreter/instructions/bitwise.ex
+++ b/lib/eevm/interpreter/instructions/bitwise.ex
@@ -30,8 +30,8 @@ defmodule EEVM.Interpreter.Instructions.Bitwise do
   """
   import Bitwise
 
-  alias EEVM.Interpreter.{MachineState, Stack}
   alias EEVM.Interpreter.Instructions.Helpers
+  alias EEVM.Interpreter.{MachineState, Stack}
 
   @max_uint256 (1 <<< 256) - 1
 

--- a/lib/eevm/interpreter/instructions/comparison.ex
+++ b/lib/eevm/interpreter/instructions/comparison.ex
@@ -24,8 +24,8 @@ defmodule EEVM.Interpreter.Instructions.Comparison do
   - `&Kernel.</2` captures the less-than operator as an anonymous function.
     The `/2` means it takes two arguments.
   """
-  alias EEVM.Interpreter.{MachineState, Stack}
   alias EEVM.Interpreter.Instructions.Helpers
+  alias EEVM.Interpreter.{MachineState, Stack}
 
   @doc """
   Dispatches and executes a comparison opcode.

--- a/lib/eevm/interpreter/instructions/control_flow.ex
+++ b/lib/eevm/interpreter/instructions/control_flow.ex
@@ -38,12 +38,10 @@ defmodule EEVM.Interpreter.Instructions.ControlFlow do
     SWAP depth adds 1 (`op - 0x90 + 1`) to include the top-of-stack position.
   """
 
-  alias EEVM.Interpreter.{MachineState, Stack}
   alias EEVM.HardforkConfig
-  alias EEVM.Interpreter.Instructions.Registry
   alias EEVM.Interpreter.Instructions.Helpers
   alias EEVM.Interpreter.Instructions.Registry
-  alias EEVM.Interpreter.Instructions.Helpers
+  alias EEVM.Interpreter.{MachineState, Stack}
 
   @doc """
   Dispatches a control flow opcode to its implementation.

--- a/lib/eevm/interpreter/instructions/crypto.ex
+++ b/lib/eevm/interpreter/instructions/crypto.ex
@@ -26,9 +26,9 @@ defmodule EEVM.Interpreter.Instructions.Crypto do
   - The binary pattern `<<hash_int::unsigned-big-256>>` decodes the raw 32-byte
     hash binary into a single 256-bit unsigned integer in one step.
   """
-  alias EEVM.Interpreter.{MachineState, Memory, Stack}
   alias EEVM.Gas.Dynamic
   alias EEVM.Gas.Memory, as: GasMemory
+  alias EEVM.Interpreter.{MachineState, Memory, Stack}
 
   @doc """
   Hashes a region of memory with Keccak-256 and pushes the result.

--- a/lib/eevm/interpreter/instructions/environment/data.ex
+++ b/lib/eevm/interpreter/instructions/environment/data.ex
@@ -9,10 +9,10 @@ defmodule EEVM.Interpreter.Instructions.Environment.Data do
   and RETURNDATACOPY (0x3E).
   """
 
-  alias EEVM.Interpreter.{MachineState, Memory, Stack}
+  alias EEVM.Context.Contract
   alias EEVM.Gas.Dynamic
   alias EEVM.Gas.Memory, as: GasMemory
-  alias EEVM.Context.Contract
+  alias EEVM.Interpreter.{MachineState, Memory, Stack}
 
   @spec execute(non_neg_integer(), MachineState.t()) ::
           {:ok, MachineState.t()} | {:error, atom(), MachineState.t()}

--- a/lib/eevm/interpreter/instructions/environment/external.ex
+++ b/lib/eevm/interpreter/instructions/environment/external.ex
@@ -10,13 +10,13 @@ defmodule EEVM.Interpreter.Instructions.Environment.External do
   EXTCODEHASH (0x3F), and SELFBALANCE (0x47).
   """
 
+  alias EEVM.Context.Contract
   alias EEVM.Database
-  alias EEVM.Interpreter.{MachineState, Memory, Stack}
   alias EEVM.Gas.Access
   alias EEVM.Gas.Dynamic
   alias EEVM.Gas.Memory, as: GasMemory
-  alias EEVM.Context.Contract
   alias EEVM.Interpreter.Instructions.Helpers
+  alias EEVM.Interpreter.{MachineState, Memory, Stack}
 
   @spec execute(non_neg_integer(), MachineState.t()) ::
           {:ok, MachineState.t()} | {:error, atom(), MachineState.t()}

--- a/lib/eevm/interpreter/instructions/environment/simple.ex
+++ b/lib/eevm/interpreter/instructions/environment/simple.ex
@@ -10,9 +10,9 @@ defmodule EEVM.Interpreter.Instructions.Environment.Simple do
   GASLIMIT, CHAINID, BASEFEE, BLOBBASEFEE, GAS, BLOCKHASH, and BLOBHASH.
   """
 
-  alias EEVM.Interpreter.{MachineState, Stack}
   alias EEVM.Context.Block
   alias EEVM.Interpreter.Instructions.Helpers
+  alias EEVM.Interpreter.{MachineState, Stack}
 
   @spec execute(non_neg_integer(), MachineState.t()) ::
           {:ok, MachineState.t()} | {:error, atom(), MachineState.t()}

--- a/lib/eevm/interpreter/instructions/logging.ex
+++ b/lib/eevm/interpreter/instructions/logging.ex
@@ -17,9 +17,9 @@ defmodule EEVM.Interpreter.Instructions.Logging do
   - `binary_part/3` extracts a slice from a binary — used to read log data from memory bytes.
   """
 
-  alias EEVM.Interpreter.{MachineState, Memory, Stack}
   alias EEVM.Gas.Dynamic
   alias EEVM.Gas.Memory, as: GasMemory
+  alias EEVM.Interpreter.{MachineState, Memory, Stack}
 
   @doc """
   Dispatches a LOG opcode (LOG0–LOG4) to the matching topic-count handler.

--- a/lib/eevm/interpreter/instructions/stack_memory_storage/memory_ops.ex
+++ b/lib/eevm/interpreter/instructions/stack_memory_storage/memory_ops.ex
@@ -12,11 +12,11 @@ defmodule EEVM.Interpreter.Instructions.StackMemoryStorage.MemoryOps do
   - **MCOPY** (0x5E) — copies a region of memory to another location (EIP-5656).
   """
 
-  alias EEVM.Interpreter.{MachineState, Memory, Stack}
   alias EEVM.Gas.Dynamic
   alias EEVM.Gas.Memory, as: GasMemory
   alias EEVM.HardforkConfig
   alias EEVM.Interpreter.Instructions.Helpers
+  alias EEVM.Interpreter.{MachineState, Memory, Stack}
 
   @spec execute(non_neg_integer(), MachineState.t()) ::
           {:ok, MachineState.t()} | {:error, atom(), MachineState.t()}

--- a/lib/eevm/interpreter/instructions/stack_memory_storage/storage_ops.ex
+++ b/lib/eevm/interpreter/instructions/stack_memory_storage/storage_ops.ex
@@ -22,9 +22,9 @@ defmodule EEVM.Interpreter.Instructions.StackMemoryStorage.StorageOps do
   """
 
   alias EEVM.Database
-  alias EEVM.Interpreter.{MachineState, Stack}
   alias EEVM.Gas.{Access, Dynamic}
   alias EEVM.HardforkConfig
+  alias EEVM.Interpreter.{MachineState, Stack}
 
   @cold_sload_cost 2100
 

--- a/lib/eevm/interpreter/instructions/system/calls.ex
+++ b/lib/eevm/interpreter/instructions/system/calls.ex
@@ -17,11 +17,12 @@ defmodule EEVM.Interpreter.Instructions.System.Calls do
   All call opcodes use EIP-150 gas forwarding: `min(requested, available - available/64)`.
   """
 
-  alias EEVM.{Database, Interpreter}
-  alias EEVM.Interpreter.{Journal, MachineState, Memory, Stack}
+  alias EEVM.Context.Contract
+  alias EEVM.Database
   alias EEVM.Gas.Dynamic
   alias EEVM.Gas.Memory, as: GasMemory
-  alias EEVM.Context.Contract
+  alias EEVM.Interpreter
+  alias EEVM.Interpreter.{Journal, MachineState, Memory, Stack}
   alias EEVM.Precompiles
 
   @spec execute(non_neg_integer(), MachineState.t()) ::

--- a/lib/eevm/interpreter/instructions/system/creation.ex
+++ b/lib/eevm/interpreter/instructions/system/creation.ex
@@ -20,11 +20,13 @@ defmodule EEVM.Interpreter.Instructions.System.Creation do
   @max_initcode_size 49_152
   @initcode_word_cost 2
 
-  alias EEVM.{Database, HardforkConfig, Interpreter}
-  alias EEVM.Interpreter.{Journal, MachineState, Memory, Stack}
+  alias EEVM.Context.Contract
+  alias EEVM.Database
   alias EEVM.Gas.Dynamic
   alias EEVM.Gas.Memory, as: GasMemory
-  alias EEVM.Context.Contract
+  alias EEVM.HardforkConfig
+  alias EEVM.Interpreter
+  alias EEVM.Interpreter.{Journal, MachineState, Memory, Stack}
 
   @spec execute(non_neg_integer(), MachineState.t()) ::
           {:ok, MachineState.t()} | {:error, atom(), MachineState.t()}

--- a/lib/eevm/interpreter/instructions/system/termination.ex
+++ b/lib/eevm/interpreter/instructions/system/termination.ex
@@ -12,9 +12,10 @@ defmodule EEVM.Interpreter.Instructions.System.Termination do
   created the contract.
   """
 
-  alias EEVM.{Database, HardforkConfig}
-  alias EEVM.Interpreter.{MachineState, Memory, Stack}
+  alias EEVM.Database
   alias EEVM.Gas.Memory, as: GasMemory
+  alias EEVM.HardforkConfig
+  alias EEVM.Interpreter.{MachineState, Memory, Stack}
 
   @spec execute(non_neg_integer(), MachineState.t()) ::
           {:ok, MachineState.t()} | {:error, atom(), MachineState.t()}

--- a/lib/eevm/interpreter/machine_state.ex
+++ b/lib/eevm/interpreter/machine_state.ex
@@ -25,13 +25,13 @@ defmodule EEVM.Interpreter.MachineState do
   - The `alias` keyword lets us reference modules by their short name.
   """
 
-  alias EEVM.Tracer
-  alias EEVM.Interpreter.{CallFrame, Memory, Stack}
   alias EEVM.Config
+  alias EEVM.Context.{Block, Contract, Transaction}
   alias EEVM.Database
   alias EEVM.Database.InMemory, as: InMemoryDB
-  alias EEVM.Context.{Block, Contract, Transaction}
+  alias EEVM.Interpreter.{CallFrame, Memory, Stack}
   alias EEVM.Precompiles
+  alias EEVM.Tracer
 
   @type status :: :running | :stopped | :reverted | :invalid | :out_of_gas | {:error, atom()}
 

--- a/lib/eevm/precompiles.ex
+++ b/lib/eevm/precompiles.ex
@@ -32,17 +32,17 @@ defmodule EEVM.Precompiles do
 
   alias EEVM.Config
   alias EEVM.HardforkConfig
-  alias EEVM.Precompiles.BN256Add
-  alias EEVM.Precompiles.BN256Mul
-  alias EEVM.Precompiles.BN256Pairing
-  alias EEVM.Precompiles.BLS12MapFp2ToG2
-  alias EEVM.Precompiles.BLS12MapFpToG1
-  alias EEVM.Precompiles.BLS12Pairing
+  alias EEVM.Precompiles.Blake2F
   alias EEVM.Precompiles.BLS12G1Add
   alias EEVM.Precompiles.BLS12G1MSM
   alias EEVM.Precompiles.BLS12G2Add
   alias EEVM.Precompiles.BLS12G2MSM
-  alias EEVM.Precompiles.Blake2F
+  alias EEVM.Precompiles.BLS12MapFp2ToG2
+  alias EEVM.Precompiles.BLS12MapFpToG1
+  alias EEVM.Precompiles.BLS12Pairing
+  alias EEVM.Precompiles.BN256Add
+  alias EEVM.Precompiles.BN256Mul
+  alias EEVM.Precompiles.BN256Pairing
   alias EEVM.Precompiles.ECRecover
   alias EEVM.Precompiles.Identity
   alias EEVM.Precompiles.KZGPointEval

--- a/lib/eevm/precompiles/bn256.ex
+++ b/lib/eevm/precompiles/bn256.ex
@@ -49,7 +49,7 @@ defmodule EEVM.Precompiles.BN256 do
     arbitrary-precision integers for coordinate parsing.
   """
 
-  alias BN.{FQ, FQ2, BN128Arithmetic, Pairing}
+  alias BN.{BN128Arithmetic, FQ, FQ2, Pairing}
 
   @field_modulus 21_888_242_871_839_275_222_246_405_745_257_275_088_696_311_157_297_823_662_689_037_894_645_226_208_583
 

--- a/lib/eevm/system_contracts/beacon_roots.ex
+++ b/lib/eevm/system_contracts/beacon_roots.ex
@@ -50,9 +50,11 @@ defmodule EEVM.SystemContracts.BeaconRoots do
     small for higher layers that aren't yet aware of full EVM state.
   """
 
-  alias EEVM.{Database, HardforkConfig, Interpreter}
-  alias EEVM.Interpreter.MachineState
   alias EEVM.Context.{Block, Contract, Transaction}
+  alias EEVM.Database
+  alias EEVM.HardforkConfig
+  alias EEVM.Interpreter
+  alias EEVM.Interpreter.MachineState
 
   @address 0x000F3DF6D732807EF1319FB7B8BB8522D0BEAC02
   @system_address 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE

--- a/lib/eevm/system_contracts/block_hashes.ex
+++ b/lib/eevm/system_contracts/block_hashes.ex
@@ -68,9 +68,11 @@ defmodule EEVM.SystemContracts.BlockHashes do
     if the caller knows the slot was written.
   """
 
-  alias EEVM.{Database, HardforkConfig, Interpreter}
-  alias EEVM.Interpreter.MachineState
   alias EEVM.Context.{Block, Contract, Transaction}
+  alias EEVM.Database
+  alias EEVM.HardforkConfig
+  alias EEVM.Interpreter
+  alias EEVM.Interpreter.MachineState
 
   @address 0x0000F90827F1C53A10CB7A02335B175320002935
   @system_address 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE

--- a/lib/eevm/transaction_result.ex
+++ b/lib/eevm/transaction_result.ex
@@ -39,8 +39,8 @@ defmodule EEVM.TransactionResult do
     cheap and keeps serializers flexible.
   """
 
-  alias EEVM.Database
   alias EEVM.Block.Bloom
+  alias EEVM.Database
 
   @type status :: :success | :reverted | :failed_validation
 

--- a/test/hardfork_config_test.exs
+++ b/test/hardfork_config_test.exs
@@ -1,9 +1,10 @@
 defmodule EEVM.HardforkConfigTest do
   use ExUnit.Case, async: true
 
-  alias EEVM.HardforkConfig
   alias EEVM.Context.Contract
-  alias EEVM.{Database, WorldState}
+  alias EEVM.Database
+  alias EEVM.HardforkConfig
+  alias EEVM.WorldState
 
   # ---------------------------------------------------------------------------
   # HardforkConfig.enabled?/2 unit tests

--- a/test/interpreter/call_frame_test.exs
+++ b/test/interpreter/call_frame_test.exs
@@ -1,9 +1,9 @@
 defmodule EEVM.CallFrameTest do
   use ExUnit.Case, async: true
 
+  alias EEVM.Context.Contract
   alias EEVM.Interpreter
   alias EEVM.Interpreter.{CallFrame, MachineState, Memory, Stack}
-  alias EEVM.Context.Contract
 
   test "push_frame stores parent frame and switches execution context" do
     parent_state = MachineState.new(<<0x00>>, contract: Contract.new(address: 1), gas: 1000)

--- a/test/interpreter/instructions/access_list_test.exs
+++ b/test/interpreter/instructions/access_list_test.exs
@@ -1,8 +1,8 @@
 defmodule EEVM.Interpreter.Instructions.AccessListTest do
   use ExUnit.Case, async: true
 
-  alias EEVM.WorldState
   alias EEVM.Context.Contract
+  alias EEVM.WorldState
 
   describe "EIP-2929 Access List Tracking" do
     test "first SLOAD is cold (2100 gas)" do

--- a/test/interpreter/instructions/blob_test.exs
+++ b/test/interpreter/instructions/blob_test.exs
@@ -1,7 +1,7 @@
 defmodule EEVM.Interpreter.Instructions.BlobTest do
   use ExUnit.Case, async: true
 
-  alias EEVM.Context.{Transaction, Block}
+  alias EEVM.Context.{Block, Transaction}
   alias EEVM.Gas.Static
 
   describe "BLOBHASH (0x49) - EIP-4844" do

--- a/test/interpreter/instructions/environment_test.exs
+++ b/test/interpreter/instructions/environment_test.exs
@@ -1,9 +1,9 @@
 defmodule EEVM.Interpreter.Instructions.EnvironmentTest do
   use ExUnit.Case, async: true
 
-  alias EEVM.Context.{Transaction, Block, Contract}
-  alias EEVM.WorldState
+  alias EEVM.Context.{Block, Contract, Transaction}
   alias EEVM.Gas.{Dynamic, Memory, Static}
+  alias EEVM.WorldState
 
   describe "Environment Opcodes" do
     test "ADDRESS pushes current contract address" do

--- a/test/interpreter/instructions/gas_refund_test.exs
+++ b/test/interpreter/instructions/gas_refund_test.exs
@@ -1,11 +1,11 @@
 defmodule EEVM.Interpreter.Instructions.GasRefundTest do
   use ExUnit.Case, async: true
 
+  alias EEVM.Context.Contract
+  alias EEVM.Context.Transaction
+  alias EEVM.Gas.Static
   alias EEVM.Interpreter
   alias EEVM.Interpreter.{CallFrame, MachineState, Memory, Stack}
-  alias EEVM.Context.Contract
-  alias EEVM.Gas.Static
-  alias EEVM.Context.Transaction
   alias EEVM.Transaction.IntrinsicGas
 
   test "refund counter defaults to 0" do

--- a/test/interpreter/instructions/selfdestruct_test.exs
+++ b/test/interpreter/instructions/selfdestruct_test.exs
@@ -1,9 +1,10 @@
 defmodule EEVM.Interpreter.Instructions.SelfdestructTest do
   use ExUnit.Case, async: true
 
-  alias EEVM.{Database, WorldState}
   alias EEVM.Context.Contract
+  alias EEVM.Database
   alias EEVM.Gas.Static
+  alias EEVM.WorldState
 
   describe "SELFDESTRUCT (0xFF) - EIP-6780 post-Cancun" do
     test "transfers balance to beneficiary" do

--- a/test/interpreter/instructions/system_test.exs
+++ b/test/interpreter/instructions/system_test.exs
@@ -3,9 +3,10 @@ defmodule EEVM.Interpreter.Instructions.SystemTest do
 
   import EEVM.TestSupport.BytecodeHelpers
 
-  alias EEVM.{Database, WorldState}
-  alias EEVM.Interpreter.Memory
   alias EEVM.Context.Contract
+  alias EEVM.Database
+  alias EEVM.Interpreter.Memory
+  alias EEVM.WorldState
 
   describe "Executor - Return & Halt" do
     test "RETURN returns data from memory" do

--- a/test/interpreter/machine_state/eip_3651_test.exs
+++ b/test/interpreter/machine_state/eip_3651_test.exs
@@ -1,10 +1,10 @@
 defmodule EEVM.Interpreter.MachineState.EIP3651Test do
   use ExUnit.Case, async: true
 
-  alias EEVM.Interpreter.MachineState
   alias EEVM.Config
-  alias EEVM.WorldState
   alias EEVM.Context.{Block, Contract, Transaction}
+  alias EEVM.Interpreter.MachineState
+  alias EEVM.WorldState
 
   describe "EIP-3651 coinbase pre-warming" do
     test "new machine state pre-warms non-zero coinbase" do

--- a/test/support/blockchain_test_fixture.ex
+++ b/test/support/blockchain_test_fixture.ex
@@ -17,6 +17,8 @@ defmodule EEVM.TestSupport.BlockchainTestFixture do
   """
 
   defmodule Account do
+    @moduledoc false
+
     @type t :: %__MODULE__{
             balance: non_neg_integer(),
             nonce: non_neg_integer(),
@@ -28,6 +30,8 @@ defmodule EEVM.TestSupport.BlockchainTestFixture do
   end
 
   defmodule TransactionFields do
+    @moduledoc false
+
     @type t :: %__MODULE__{
             sender: non_neg_integer(),
             nonce: non_neg_integer(),
@@ -62,6 +66,8 @@ defmodule EEVM.TestSupport.BlockchainTestFixture do
   end
 
   defmodule BlockHeader do
+    @moduledoc false
+
     @type t :: %__MODULE__{
             parent_hash: binary(),
             coinbase: non_neg_integer(),
@@ -112,6 +118,8 @@ defmodule EEVM.TestSupport.BlockchainTestFixture do
   end
 
   defmodule Withdrawal do
+    @moduledoc false
+
     @type t :: %__MODULE__{
             index: non_neg_integer(),
             validator_index: non_neg_integer(),
@@ -123,6 +131,8 @@ defmodule EEVM.TestSupport.BlockchainTestFixture do
   end
 
   defmodule Block do
+    @moduledoc false
+
     @type t :: %__MODULE__{
             block_number: non_neg_integer(),
             header: BlockHeader.t() | nil,
@@ -143,6 +153,8 @@ defmodule EEVM.TestSupport.BlockchainTestFixture do
   end
 
   defmodule Case do
+    @moduledoc false
+
     @type t :: %__MODULE__{
             name: String.t(),
             network: EEVM.HardforkConfig.spec_id(),

--- a/test/support/blockchain_test_runner.ex
+++ b/test/support/blockchain_test_runner.ex
@@ -22,15 +22,18 @@ defmodule EEVM.TestSupport.BlockchainTestRunner do
   """
 
   alias EEVM.Block.{Header, Processor}
+  alias EEVM.Config
   alias EEVM.Context.{Block, Transaction}
+  alias EEVM.Database
   alias EEVM.Database.InMemory
   alias EEVM.Handler.Execution
+  alias EEVM.HardforkConfig
+  alias EEVM.StateRoot
   alias EEVM.SystemContracts.{BeaconRoots, BlockHashes}
   alias EEVM.TestSupport.BlockchainHeaderValidator, as: HeaderValidator
   alias EEVM.TestSupport.BlockchainTestFixture.{Account, Case, TransactionFields, Withdrawal}
   alias EEVM.TestSupport.BlockchainTestFixture.Block, as: FixtureBlock
   alias EEVM.Transaction.{IntrinsicGas, Validator}
-  alias EEVM.{Config, Database, HardforkConfig, StateRoot}
 
   @min_blob_base_fee 1
 

--- a/test/support/state_test_fixture.ex
+++ b/test/support/state_test_fixture.ex
@@ -6,6 +6,8 @@ defmodule EEVM.TestSupport.StateTestFixture do
   @empty_logs_hash "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
 
   defmodule Case do
+    @moduledoc false
+
     @type t :: %__MODULE__{
             name: String.t(),
             env: EEVM.TestSupport.StateTestFixture.Env.t(),
@@ -23,6 +25,8 @@ defmodule EEVM.TestSupport.StateTestFixture do
   end
 
   defmodule Env do
+    @moduledoc false
+
     @type t :: %__MODULE__{
             coinbase: non_neg_integer(),
             number: non_neg_integer(),
@@ -49,6 +53,8 @@ defmodule EEVM.TestSupport.StateTestFixture do
   end
 
   defmodule TransactionTemplate do
+    @moduledoc false
+
     @type t :: %__MODULE__{
             nonce: non_neg_integer(),
             secret_key: binary(),
@@ -83,6 +89,8 @@ defmodule EEVM.TestSupport.StateTestFixture do
   end
 
   defmodule PostExpectation do
+    @moduledoc false
+
     @type t :: %__MODULE__{
             hardfork: EEVM.HardforkConfig.spec_id(),
             hash: binary(),

--- a/test/system_contracts/beacon_roots_test.exs
+++ b/test/system_contracts/beacon_roots_test.exs
@@ -1,10 +1,11 @@
 defmodule EEVM.SystemContracts.BeaconRootsTest do
   use ExUnit.Case, async: true
 
-  alias EEVM.Database.InMemory
-  alias EEVM.{Database, HardforkConfig}
-  alias EEVM.Interpreter.MachineState
   alias EEVM.Context.{Block, Contract, Transaction}
+  alias EEVM.Database
+  alias EEVM.Database.InMemory
+  alias EEVM.HardforkConfig
+  alias EEVM.Interpreter.MachineState
   alias EEVM.SystemContracts.BeaconRoots
 
   @history 8191

--- a/test/system_contracts/block_hashes_test.exs
+++ b/test/system_contracts/block_hashes_test.exs
@@ -1,10 +1,11 @@
 defmodule EEVM.SystemContracts.BlockHashesTest do
   use ExUnit.Case, async: true
 
-  alias EEVM.Database.InMemory
-  alias EEVM.{Database, HardforkConfig}
-  alias EEVM.Interpreter.MachineState
   alias EEVM.Context.{Block, Contract, Transaction}
+  alias EEVM.Database
+  alias EEVM.Database.InMemory
+  alias EEVM.HardforkConfig
+  alias EEVM.Interpreter.MachineState
   alias EEVM.SystemContracts.BlockHashes
 
   @window 8191


### PR DESCRIPTION
## Summary
- Re-enable Credo's `Readability.AliasOrder` and `Readability.ModuleDoc` checks (previously disabled)
- Sort all `alias` groups alphabetically across lib/ and test/ (~30 files)
- Add `@moduledoc false` to 10 nested helper modules in test/support/
- Use the atom-list defstruct form in `EEVM.Config` (no field gets an explicit `nil` default)

Aligns the codebase with the [community Elixir style guide](https://github.com/christopheradams/elixir_style_guide).

## Test plan
- [x] `mix credo --strict` clean (was 49 issues, now 0)
- [x] `mix test` — 4 doctests, 613 tests, 0 failures
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix docs` builds without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)