### PR TITLE
refactor: unify parent_hash representation as binary (#128)

### DIFF
--- a/lib/eevm/system_contracts/block_hashes.ex
+++ b/lib/eevm/system_contracts/block_hashes.ex
@@ -133,12 +133,10 @@ defmodule EEVM.SystemContracts.BlockHashes do
   should never happen with the canonical bytecode, but we surface it rather
   than swallow it).
   """
-  @spec commit(Database.t(), Block.t(), non_neg_integer()) ::
+  @spec commit(Database.t(), Block.t(), <<_::256>>) ::
           {:ok, Database.t()} | {:error, atom(), Database.t()}
   def commit(%Database{} = db, %Block{} = block, parent_block_hash)
-      when is_integer(parent_block_hash) and parent_block_hash >= 0 do
-    calldata = <<parent_block_hash::unsigned-big-256>>
-
+      when is_binary(parent_block_hash) and byte_size(parent_block_hash) == 32 do
     final_state =
       @deployed_code
       |> MachineState.new(
@@ -149,7 +147,7 @@ defmodule EEVM.SystemContracts.BlockHashes do
           address: @address,
           caller: @system_address,
           callvalue: 0,
-          calldata: calldata
+          calldata: parent_block_hash
         },
         gas: @system_call_gas
       )

--- a/test/support/blockchain_test_runner.ex
+++ b/test/support/blockchain_test_runner.ex
@@ -202,18 +202,12 @@ defmodule EEVM.TestSupport.BlockchainTestRunner do
       unwrap_system_call(BeaconRoots.commit(db, block_ctx, header.parent_beacon_block_root || 0))
     end)
     |> maybe_append(enabled_2935?, fn db, block_ctx ->
-      unwrap_system_call(
-        BlockHashes.commit(db, block_ctx, parent_hash_to_int(header.parent_hash))
-      )
+      unwrap_system_call(BlockHashes.commit(db, block_ctx, header.parent_hash))
     end)
   end
 
   defp unwrap_system_call({:ok, %Database{} = db}), do: db
   defp unwrap_system_call({:error, _reason, %Database{} = db}), do: db
-
-  defp parent_hash_to_int(nil), do: 0
-  defp parent_hash_to_int(<<value::unsigned-big-256>>), do: value
-  defp parent_hash_to_int(value) when is_integer(value), do: value
 
   defp maybe_append(list, false, _fun), do: list
   defp maybe_append(list, true, fun), do: list ++ [fun]

--- a/test/system_contracts/block_hashes_test.exs
+++ b/test/system_contracts/block_hashes_test.exs
@@ -46,7 +46,7 @@ defmodule EEVM.SystemContracts.BlockHashesTest do
       block = %Block{number: 1_000_001}
       hash = 0xDEADBEEFCAFEBABE0000000000000000000000000000000000000000FACEFEED
 
-      {:ok, db} = BlockHashes.commit(db, block, hash)
+      {:ok, db} = BlockHashes.commit(db, block, <<hash::256>>)
 
       slot = rem(1_000_000, @window)
       assert Database.storage_load(db, BlockHashes.address(), slot) == hash
@@ -56,7 +56,7 @@ defmodule EEVM.SystemContracts.BlockHashesTest do
       db = BlockHashes.install(InMemory.new())
       hash = 0xFEED0001
 
-      {:ok, db} = BlockHashes.commit(db, %Block{number: 1_000_001}, hash)
+      {:ok, db} = BlockHashes.commit(db, %Block{number: 1_000_001}, <<hash::256>>)
 
       assert BlockHashes.lookup(db, 1_000_000) == {:ok, hash}
     end
@@ -70,8 +70,8 @@ defmodule EEVM.SystemContracts.BlockHashesTest do
       db = BlockHashes.install(InMemory.new())
 
       # parent block 1_000 then parent block 1_000 + 8191 — same ring slot.
-      {:ok, db} = BlockHashes.commit(db, %Block{number: 1_001}, 0xAAAA)
-      {:ok, db} = BlockHashes.commit(db, %Block{number: 1_001 + @window}, 0xBBBB)
+      {:ok, db} = BlockHashes.commit(db, %Block{number: 1_001}, <<0xAAAA::256>>)
+      {:ok, db} = BlockHashes.commit(db, %Block{number: 1_001 + @window}, <<0xBBBB::256>>)
 
       assert BlockHashes.lookup(db, 1_000) == {:ok, 0xBBBB}
       assert BlockHashes.lookup(db, 1_000 + @window) == {:ok, 0xBBBB}
@@ -85,7 +85,7 @@ defmodule EEVM.SystemContracts.BlockHashesTest do
       hash = 0x1111111111111111111111111111111111111111111111111111111111111111
 
       db = BlockHashes.install(InMemory.new())
-      {:ok, db} = BlockHashes.commit(db, %Block{number: block_number}, hash)
+      {:ok, db} = BlockHashes.commit(db, %Block{number: block_number}, <<hash::256>>)
 
       final_state = call_contract(db, block_number, target_block)
 


### PR DESCRIPTION
## Summary

- `Block.Header.parent_hash` was already canonicalised as a 32-byte `binary()`, but `BlockHashes.commit/3` took a `non_neg_integer()` — forcing a `parent_hash_to_int` shim in `BlockchainTestRunner` that handled `nil` / `binary` / `integer`.
- Switch `commit/3` to accept the 32-byte binary directly (the calldata was already encoded as 32 bytes), pass `header.parent_hash` through unchanged, and delete the shim.
- Net -8 LOC. Closes #128.

## Test plan

- [x] `mix compile` clean
- [x] `mix credo --strict` clean
- [x] `mix test` — 4 doctests, 613 tests, 0 failures
- [x] `mix test test/system_contracts/block_hashes_test.exs` — 11 tests, 0 failures
- [x] `mix test test/blockchain_test_test.exs` — 2 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)