### PR TITLE
refactor(block): fold withdrawals into Block.Processor

### DIFF
--- a/lib/eevm/block/processor.ex
+++ b/lib/eevm/block/processor.ex
@@ -1,7 +1,8 @@
 defmodule EEVM.Block.Processor do
   @moduledoc """
   Execute a block end-to-end: system calls, then transactions in order, then
-  the commitments a consensus-level verifier will check.
+  beacon-chain withdrawals, then the commitments a consensus-level verifier
+  will check.
 
   ## EVM Concepts
 
@@ -43,6 +44,10 @@ defmodule EEVM.Block.Processor do
     `transactions_root`. Defaults to `EEVM.Transaction.Envelope.encode/1`,
     which handles every typed envelope this codebase knows about. Tests
     using plain maps supply their own.
+  - `:withdrawals` — list of `EEVM.Block.Withdrawal` structs (EIP-4895).
+    Applied as flat balance credits after the transaction fold and before
+    the state root is computed, so the returned `state_root` already
+    reflects them. Defaults to `[]`.
   - `:hardfork` — optional atom, purely informational today; the real
     executor will consume it once wired in.
 
@@ -61,12 +66,14 @@ defmodule EEVM.Block.Processor do
     bitwise OR already optimised in the bloom module.
   """
 
-  alias EEVM.Block.{Bloom, Header, Receipt, Result}
+  alias EEVM.Block.{Bloom, Header, Receipt, Result, Withdrawal}
   alias EEVM.Context.Block, as: BlockCtx
   alias EEVM.Database
   alias EEVM.MPT.Trie
   alias EEVM.StateRoot
   alias EEVM.Transaction.Envelope
+
+  @gwei 1_000_000_000
 
   @type tx_result :: %{
           required(:status) => 0 | 1,
@@ -86,6 +93,7 @@ defmodule EEVM.Block.Processor do
           tx_executor: tx_executor(),
           system_calls: [system_call()],
           tx_encoder: tx_encoder(),
+          withdrawals: [Withdrawal.t()],
           hardfork: atom() | nil
         ]
 
@@ -114,6 +122,7 @@ defmodule EEVM.Block.Processor do
     tx_executor = fetch_executor!(opts)
     system_calls = Keyword.get(opts, :system_calls, [])
     tx_encoder = Keyword.get(opts, :tx_encoder, &Envelope.encode/1)
+    withdrawals = Keyword.get(opts, :withdrawals, [])
 
     block_ctx = to_block_ctx(header)
 
@@ -121,7 +130,8 @@ defmodule EEVM.Block.Processor do
       db_after_system = apply_system_calls(pre_state_db, block_ctx, system_calls)
 
       case execute_transactions(transactions, block_ctx, db_after_system, tx_executor) do
-        {:ok, receipts, post_db, gas_used} ->
+        {:ok, receipts, post_tx_db, gas_used} ->
+          post_db = apply_withdrawals(post_tx_db, withdrawals)
           {:ok, build_result(post_db, receipts, transactions, gas_used, tx_encoder)}
 
         {:error, _} = error ->
@@ -202,7 +212,25 @@ defmodule EEVM.Block.Processor do
   end
 
   # ---------------------------------------------------------------------------
-  # Phase 4 — commitments
+  # Phase 4 — withdrawals (EIP-4895)
+  # ---------------------------------------------------------------------------
+
+  # Each withdrawal is a flat balance credit; `amount` is in gwei per the EIP,
+  # so we scale to wei before applying.
+  @spec apply_withdrawals(Database.t(), [Withdrawal.t()]) :: Database.t()
+  defp apply_withdrawals(db, withdrawals) do
+    Enum.reduce(withdrawals, db, fn %Withdrawal{address: addr, amount: amount}, db_acc ->
+      credit_balance(db_acc, addr, amount * @gwei)
+    end)
+  end
+
+  defp credit_balance(db, _addr, 0), do: db
+
+  defp credit_balance(db, addr, amount),
+    do: Database.set_balance(db, addr, Database.get_balance(db, addr) + amount)
+
+  # ---------------------------------------------------------------------------
+  # Phase 5 — commitments
   # ---------------------------------------------------------------------------
 
   @spec build_result(

--- a/lib/eevm/block/withdrawal.ex
+++ b/lib/eevm/block/withdrawal.ex
@@ -1,0 +1,30 @@
+defmodule EEVM.Block.Withdrawal do
+  @moduledoc """
+  EIP-4895 beacon-chain withdrawal: a credit applied to an execution-layer
+  account at the start of a block.
+
+  ## EVM Concepts
+
+  Validators on the beacon chain accumulate rewards (and partial-stake exits)
+  that periodically need to land on the execution layer as plain balance
+  increases. The consensus layer hands the execution client a flat list of
+  these credits per block. They are not transactions: there is no signature,
+  no gas, no nonce, and no possibility of failure. The execution client
+  simply iterates the list and adds each `amount` to `address`.
+
+  Per EIP-4895 the wire `amount` is denominated in *gwei*; the EVM works in
+  wei everywhere else, so the actual balance bump is `amount * 1_000_000_000`.
+
+  Withdrawals are folded into block processing alongside transactions: the
+  state root the header advertises is post-withdrawals.
+  """
+
+  @type t :: %__MODULE__{
+          index: non_neg_integer(),
+          validator_index: non_neg_integer(),
+          address: non_neg_integer(),
+          amount: non_neg_integer()
+        }
+
+  defstruct index: 0, validator_index: 0, address: 0, amount: 0
+end

--- a/test/block/processor_test.exs
+++ b/test/block/processor_test.exs
@@ -1,7 +1,7 @@
 defmodule EEVM.Block.ProcessorTest do
   use ExUnit.Case, async: true
 
-  alias EEVM.Block.{Bloom, Header, Processor, Receipt, Result}
+  alias EEVM.Block.{Bloom, Header, Processor, Receipt, Result, Withdrawal}
   alias EEVM.{Database, StateRoot}
   alias EEVM.Database.InMemory
   alias EEVM.MPT.Trie
@@ -287,6 +287,76 @@ defmodule EEVM.Block.ProcessorTest do
       assert r2.logs_bloom == Bloom.from_logs([log_b])
 
       assert result.logs_bloom == Bloom.merge(r1.logs_bloom, r2.logs_bloom)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Withdrawals (EIP-4895)
+  # ---------------------------------------------------------------------------
+
+  describe "withdrawals" do
+    test "credits each address with amount * 1_000_000_000 (gwei → wei)" do
+      db = InMemory.new()
+      header = noop_header()
+
+      withdrawals = [
+        %Withdrawal{index: 0, validator_index: 1, address: 0xAAAA, amount: 5},
+        %Withdrawal{index: 1, validator_index: 2, address: 0xBBBB, amount: 7}
+      ]
+
+      {:ok, result} = run(header, [], db, withdrawals: withdrawals)
+
+      assert Database.get_balance(result.post_state_db, 0xAAAA) == 5_000_000_000
+      assert Database.get_balance(result.post_state_db, 0xBBBB) == 7_000_000_000
+    end
+
+    test "state_root reflects withdrawals (applied before commitments)" do
+      db = InMemory.new()
+      header = noop_header()
+      pre_root = StateRoot.compute_state_root(db)
+
+      {:ok, result} =
+        run(header, [], db,
+          withdrawals: [%Withdrawal{index: 0, validator_index: 0, address: 0xCAFE, amount: 1}]
+        )
+
+      assert result.state_root != pre_root
+      assert result.state_root == StateRoot.compute_state_root(result.post_state_db)
+    end
+
+    test "applies after the transaction fold so txs cannot observe the credit" do
+      db = InMemory.new()
+      header = noop_header()
+
+      observing_executor = fn _tx, _ctx, db_in ->
+        observed = Database.get_balance(db_in, 0xCAFE)
+        new_db = Database.set_balance(db_in, 0xCAFE_BABE, observed)
+        {:ok, %{status: 1, gas_used: 21_000, logs: [], db: new_db}}
+      end
+
+      {:ok, result} =
+        Processor.process_block(
+          header,
+          [tx(id: 1, gas_limit: 100_000)],
+          db,
+          tx_executor: observing_executor,
+          tx_encoder: tx_encoder(),
+          withdrawals: [%Withdrawal{index: 0, validator_index: 0, address: 0xCAFE, amount: 1}]
+        )
+
+      # The tx ran *before* the withdrawal landed, so it observed a zero balance.
+      assert Database.get_balance(result.post_state_db, 0xCAFE_BABE) == 0
+      assert Database.get_balance(result.post_state_db, 0xCAFE) == 1_000_000_000
+    end
+
+    test "empty withdrawals list is a no-op" do
+      db = InMemory.new()
+      header = noop_header()
+      pre_root = StateRoot.compute_state_root(db)
+
+      {:ok, result} = run(header, [], db, withdrawals: [])
+
+      assert result.state_root == pre_root
     end
   end
 

--- a/test/support/blockchain_test_runner.ex
+++ b/test/support/blockchain_test_runner.ex
@@ -21,17 +21,17 @@ defmodule EEVM.TestSupport.BlockchainTestRunner do
   follow-ups.
   """
 
-  alias EEVM.Block.{Header, Processor}
+  alias EEVM.Block.{Header, Processor, Withdrawal}
   alias EEVM.Config
   alias EEVM.Context.{Block, Transaction}
   alias EEVM.Database
   alias EEVM.Database.InMemory
   alias EEVM.HardforkConfig
-  alias EEVM.StateRoot
   alias EEVM.SystemContracts.{BeaconRoots, BlockHashes}
   alias EEVM.TestSupport.BlockchainHeaderValidator, as: HeaderValidator
-  alias EEVM.TestSupport.BlockchainTestFixture.{Account, Case, TransactionFields, Withdrawal}
+  alias EEVM.TestSupport.BlockchainTestFixture.{Account, Case, TransactionFields}
   alias EEVM.TestSupport.BlockchainTestFixture.Block, as: FixtureBlock
+  alias EEVM.TestSupport.BlockchainTestFixture.Withdrawal, as: FixtureWithdrawal
   alias EEVM.TestSupport.TxExecutor
 
   @min_blob_base_fee 1
@@ -119,22 +119,20 @@ defmodule EEVM.TestSupport.BlockchainTestRunner do
     opts = [
       tx_executor: tx_executor(config, header),
       tx_encoder: fn _tx -> <<>> end,
-      system_calls: system_calls(header, config)
+      system_calls: system_calls(header, config),
+      withdrawals: Enum.map(block.withdrawals, &to_eevm_withdrawal/1)
     ]
 
     case Processor.process_block(eevm_header, transactions, db, opts) do
       {:ok, result} ->
-        verify_post_block(result, header, block.withdrawals)
+        verify_post_block(result, header)
 
       {:error, _} = error ->
         error
     end
   end
 
-  defp verify_post_block(result, header, withdrawals) do
-    final_db = apply_withdrawals(result.post_state_db, withdrawals)
-    final_state_root = StateRoot.compute_state_root(final_db)
-
+  defp verify_post_block(result, header) do
     cond do
       result.gas_used != header.gas_used ->
         {:error, {:invalid_gas_used, expected: header.gas_used, actual: result.gas_used}}
@@ -142,20 +140,22 @@ defmodule EEVM.TestSupport.BlockchainTestRunner do
       result.logs_bloom != header.logs_bloom ->
         {:error, :invalid_logs_bloom}
 
-      final_state_root != header.state_root ->
-        {:error, {:state_root_mismatch, expected: header.state_root, actual: final_state_root}}
+      result.state_root != header.state_root ->
+        {:error,
+         {:state_root_mismatch, expected: header.state_root, actual: result.state_root}}
 
       true ->
-        {:ok, final_db}
+        {:ok, result.post_state_db}
     end
   end
 
-  @gwei 1_000_000_000
-
-  defp apply_withdrawals(db, withdrawals) do
-    Enum.reduce(withdrawals, db, fn %Withdrawal{address: addr, amount: amount}, db_acc ->
-      credit_balance(db_acc, addr, amount * @gwei)
-    end)
+  defp to_eevm_withdrawal(%FixtureWithdrawal{} = w) do
+    %Withdrawal{
+      index: w.index,
+      validator_index: w.validator_index,
+      address: w.address,
+      amount: w.amount
+    }
   end
 
   defp to_eevm_header(header) do
@@ -239,11 +239,6 @@ defmodule EEVM.TestSupport.BlockchainTestRunner do
     blob_base_fee = if header.excess_blob_gas == nil, do: 0, else: @min_blob_base_fee
     %{block_ctx | blob_base_fee: blob_base_fee}
   end
-
-  defp credit_balance(db, _addr, 0), do: db
-
-  defp credit_balance(db, addr, amount),
-    do: Database.set_balance(db, addr, Database.get_balance(db, addr) + amount)
 
   defp verify_post_state(db, post) do
     Enum.find_value(post, :ok, fn {addr, %Account{} = expected} ->

--- a/test/support/blockchain_test_runner.ex
+++ b/test/support/blockchain_test_runner.ex
@@ -141,8 +141,7 @@ defmodule EEVM.TestSupport.BlockchainTestRunner do
         {:error, :invalid_logs_bloom}
 
       result.state_root != header.state_root ->
-        {:error,
-         {:state_root_mismatch, expected: header.state_root, actual: result.state_root}}
+        {:error, {:state_root_mismatch, expected: header.state_root, actual: result.state_root}}
 
       true ->
         {:ok, result.post_state_db}


### PR DESCRIPTION
## Summary

- Withdrawals (EIP-4895) were applied in `BlockchainTestRunner` *after* `Block.Processor.process_block/4` returned, then the runner recomputed the state root. A real client folds these credits into block processing so the returned `state_root` already reflects them.
- New module `EEVM.Block.Withdrawal` (lib/) plus a `:withdrawals` option on `process_block/4`, applied between the transaction fold and the commitments phase.
- The runner now converts fixture withdrawals to the new struct, passes them through, and asserts on `result.state_root` directly — the `apply_withdrawals` / `credit_balance` / `StateRoot` helpers in the runner are gone.
- Closes #126.

## Test plan

- [x] `mix compile` clean
- [x] `mix credo --strict` clean
- [x] `mix test` — 4 doctests, 617 tests, 0 failures (4 new tests cover gwei→wei conversion, state root reflects withdrawals, ordering relative to txs, empty list no-op)
- [x] Existing BlockchainTest harness still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)